### PR TITLE
Add Ray actor manager and tests

### DIFF
--- a/src/codin/actor/__init__.py
+++ b/src/codin/actor/__init__.py
@@ -8,6 +8,7 @@ and dispatchers for routing requests between agents.
 from .dispatcher import DispatchRequest, DispatchResult, Dispatcher, LocalDispatcher
 from .mailbox import AsyncMailbox, LocalAsyncMailbox, Mailbox, MailboxMessage
 from .scheduler import ActorInfo, ActorScheduler, LocalActorManager
+from .ray_scheduler import RayActorManager
 
 
 __all__ = [
@@ -19,6 +20,7 @@ __all__ = [
     # Actor manager types
     'ActorScheduler',
     'LocalActorManager',
+    'RayActorManager',
     'ActorInfo',
     # Dispatcher types
     'Dispatcher',

--- a/src/codin/actor/ray_scheduler.py
+++ b/src/codin/actor/ray_scheduler.py
@@ -1,0 +1,102 @@
+"""Ray-based actor scheduler for distributed agent execution."""
+
+from __future__ import annotations
+
+import typing as _t
+from datetime import datetime
+
+from pydantic import Field
+
+from .scheduler import ActorInfo, ActorScheduler
+
+if _t.TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from ..agent.base import Agent
+    from ..agent.types import AgentRunInput
+
+
+try:  # pragma: no cover - optional dependency
+    import ray
+except Exception:  # pragma: no cover
+    ray = None
+
+
+__all__ = ["RayActorManager"]
+
+
+class _RayAgentWrapper:
+    """Ray remote wrapper executing an Agent."""
+
+    def __init__(self, agent: "Agent") -> None:  # pragma: no cover - executed on ray worker
+        self._agent = agent
+
+    def run(self, input_data: dict) -> list[dict]:  # pragma: no cover - executed on ray worker
+        import asyncio
+        from ..agent.types import AgentRunInput
+
+        data = AgentRunInput(**input_data)
+        outputs: list[dict] = []
+
+        async def _collect() -> None:
+            async for out in self._agent.run(data):
+                outputs.append(out.dict())
+
+        asyncio.run(_collect())
+        return outputs
+
+    def cleanup(self) -> None:  # pragma: no cover - executed on ray worker
+        import asyncio
+
+        if hasattr(self._agent, "cleanup"):
+            asyncio.run(self._agent.cleanup())
+
+
+if ray:  # pragma: no cover - avoid ray usage when not available
+    RayAgentActor = ray.remote(_RayAgentWrapper)
+else:  # pragma: no cover
+    RayAgentActor = None
+
+
+class RayActorManager(ActorScheduler):
+    """Manage agents as Ray actors."""
+
+    def __init__(self, agent_factory: _t.Callable[[str, str], _t.Awaitable["Agent"]] | None = None) -> None:
+        if ray is None:
+            raise ImportError("ray is required for RayActorManager")
+        self._actors: dict[str, ActorInfo] = {}
+        self._factory = agent_factory
+
+    async def get_or_create(self, actor_type: str, key: str) -> "ray.actor.ActorHandle":
+        actor_id = f"{actor_type}:{key}"
+        if actor_id in self._actors:
+            info = self._actors[actor_id]
+            info.last_accessed = datetime.now()
+            return info.agent
+
+        if self._factory:
+            agent = await self._factory(actor_type, key)
+        else:
+            from ..agent.code_planner import CodePlanner
+            from ..agent.base_agent import BaseAgent
+
+            planner = CodePlanner()
+            agent = BaseAgent(agent_id=actor_id, name=f"{actor_type}-{key}", planner=planner)
+
+        handle = RayAgentActor.remote(agent)
+        info = ActorInfo(actor_id=actor_id, actor_type=actor_type, agent=handle)
+        self._actors[actor_id] = info
+        return handle
+
+    async def deactivate(self, agent_id: str) -> None:
+        info = self._actors.pop(agent_id, None)
+        if info is None:
+            return
+        try:
+            await info.agent.cleanup.remote()
+        finally:  # pragma: no cover - best effort
+            ray.kill(info.agent)
+
+    async def list_actors(self) -> list[ActorInfo]:
+        return list(self._actors.values())
+
+    async def get_actor_info(self, agent_id: str) -> ActorInfo | None:
+        return self._actors.get(agent_id)

--- a/tests/actor/test_ray_scheduler.py
+++ b/tests/actor/test_ray_scheduler.py
@@ -1,0 +1,23 @@
+import pytest
+
+from codin.actor.ray_scheduler import RayActorManager
+
+
+@pytest.mark.asyncio
+async def test_ray_actor_manager_basic():
+    ray = pytest.importorskip("ray")
+    ray.init(local_mode=True, ignore_reinit_error=True)
+
+    manager = RayActorManager()
+    agent = await manager.get_or_create("test_agent", "1")
+    assert agent is not None
+
+    actors = await manager.list_actors()
+    assert len(actors) == 1
+    info = await manager.get_actor_info("test_agent:1")
+    assert info is not None
+
+    await manager.deactivate("test_agent:1")
+    actors_after = await manager.list_actors()
+    assert len(actors_after) == 0
+    ray.shutdown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,23 @@
 """Global pytest configuration and fixtures."""
 
 import os
+import sys
+import types
 import asyncio
 import logging
 import pytest
 import typing as _t
 from unittest.mock import AsyncMock, MagicMock, patch
+
+# Ensure 'src.codin' imports refer to local 'codin' package
+import codin as _codin
+sys.modules.setdefault('src', types.ModuleType('src'))
+sys.modules['src.codin'] = _codin
+import codin.runtime.base as _runtime_base
+import codin.runtime.local as _runtime_local
+sys.modules['src.codin.runtime'] = sys.modules['codin.runtime']
+sys.modules['src.codin.runtime.base'] = _runtime_base
+sys.modules['src.codin.runtime.local'] = _runtime_local
 
 # Configure logging for tests
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- add optional `RayActorManager` for distributed agent handling
- expose new manager in actor package
- provide tests for ray scheduler
- adjust actor tests to use lightweight dummy agent
- ensure `src.codin` imports resolve to local package for tests

## Testing
- `PYTHONPATH=src pytest tests/actor/test_mailbox_system.py::test_local_actor_manager -q`
- `PYTHONPATH=src pytest tests/actor/test_ray_scheduler.py::test_ray_actor_manager_basic -q`
- `PYTHONPATH=src pytest tests/runtime/test_local_runtime.py::test_run_cli_streaming -q`


------
https://chatgpt.com/codex/tasks/task_e_6842d6016f508320a22aef2d849c44fc