### PR TITLE
Rename CodePlanner to BasePlanner

### DIFF
--- a/src/codin/actor/ray_scheduler.py
+++ b/src/codin/actor/ray_scheduler.py
@@ -75,10 +75,10 @@ class RayActorManager(ActorScheduler):
         if self._factory:
             agent = await self._factory(actor_type, key)
         else:
-            from ..agent.code_planner import CodePlanner
+            from ..agent.base_planner import BasePlanner
             from ..agent.base_agent import BaseAgent
 
-            planner = CodePlanner()
+            planner = BasePlanner()
             agent = BaseAgent(agent_id=actor_id, name=f"{actor_type}-{key}", planner=planner)
 
         handle = RayAgentActor.remote(agent)

--- a/src/codin/actor/scheduler.py
+++ b/src/codin/actor/scheduler.py
@@ -81,9 +81,9 @@ class LocalActorManager(ActorScheduler):
         else:
             # Default agent creation - import here to avoid circular import
             from ..agent.base_agent import BaseAgent
-            from ..agent.code_planner import CodePlanner
+            from ..agent.base_planner import BasePlanner
 
-            planner = CodePlanner()
+            planner = BasePlanner()
             agent = BaseAgent(name=f'{actor_type}-{key}', agent_id=actor_id, planner=planner)
 
         # Store actor info

--- a/src/codin/agent/__init__.py
+++ b/src/codin/agent/__init__.py
@@ -47,11 +47,11 @@ def get_base_agent():
     return BaseAgent
 
 
-def get_code_planner():
-    """Lazy import CodePlanner to avoid circular imports."""
-    from .code_planner import CodePlanner, CodePlannerConfig
+def get_base_planner():
+    """Lazy import BasePlanner to avoid circular imports."""
+    from .base_planner import BasePlanner, BasePlannerConfig
 
-    return CodePlanner, CodePlannerConfig
+    return BasePlanner, BasePlannerConfig
 
 
 def get_code_agent():
@@ -94,6 +94,6 @@ __all__ = [
     'Mailbox',
     # Lazy access functions
     'get_base_agent',
-    'get_code_planner',
+    'get_base_planner',
     'get_code_agent',
 ]

--- a/src/codin/agent/base_planner.py
+++ b/src/codin/agent/base_planner.py
@@ -1,4 +1,4 @@
-"""CodePlanner is a planner that uses LLM to generate execution steps, adapted from CodeAgent."""
+"""BasePlanner is a planner that uses LLM to generate execution steps, adapted from CodeAgent."""
 
 import json
 import logging
@@ -19,15 +19,15 @@ from .types import FinishStep, MessageStep, Planner, State, Step, ThinkStep, Too
 
 
 __all__ = [
-    'CodePlanner',
-    'CodePlannerConfig',
+    'BasePlanner',
+    'BasePlannerConfig',
 ]
 
-logger = logging.getLogger('codin.agent.code_planner')
+logger = logging.getLogger('codin.agent.base_planner')
 
 
-class CodePlannerConfig(BaseModel):
-    """Configuration for CodePlanner."""
+class BasePlannerConfig(BaseModel):
+    """Configuration for BasePlanner."""
 
     model: str = 'gpt-4'
     max_tokens: int = 4000
@@ -38,17 +38,17 @@ class CodePlannerConfig(BaseModel):
     rules: str | None = None
 
 
-class CodePlanner(Planner):
+class BasePlanner(Planner):
     """Planner that uses LLM to generate execution steps, adapted from CodeAgent."""
 
     def __init__(
         self,
-        config: CodePlannerConfig | None = None,
+        config: BasePlannerConfig | None = None,
         llm: BaseLLM | None = None,
         tool_registry: ToolRegistry | None = None,
         debug: bool = False,
     ):
-        """Initialize the CodePlanner.
+        """Initialize the BasePlanner.
 
         Args:
             config: Planner configuration
@@ -56,12 +56,12 @@ class CodePlanner(Planner):
             tool_registry: Tool registry for available tools
             debug: Enable debug logging
         """
-        self.config = config or CodePlannerConfig()
+        self.config = config or BasePlannerConfig()
         self.llm = llm or LLMFactory.create_llm(model=self.config.model)
         self.tool_registry = tool_registry or ToolRegistry()
         self.debug = debug
 
-        logger.info(f'Initialized CodePlanner with {len(self.tool_registry.get_tools())} tools')
+        logger.info(f'Initialized BasePlanner with {len(self.tool_registry.get_tools())} tools')
 
     async def next(self, state: State) -> _t.AsyncGenerator[Step]:
         """Generate execution steps based on current state."""
@@ -213,7 +213,7 @@ class CodePlanner(Planner):
             tool_results_text = self._format_tool_results_for_conversation(state.last_tool_results)
 
         return {
-            'agent_name': 'CodePlanner',
+            'agent_name': 'BasePlanner',
             'task_id': state.session_id,
             'turn_count': state.turn_count,
             'has_tools': len(tool_definitions) > 0,
@@ -412,11 +412,11 @@ class CodePlanner(Planner):
 
     async def reset(self, state: State) -> None:
         """Reset the planner to the initial state."""
-        # For CodePlanner, resetting means clearing any internal state
-        # Since CodePlanner is stateless (each call to next() is independent),
+        # For BasePlanner, resetting means clearing any internal state
+        # Since BasePlanner is stateless (each call to next() is independent),
         # we don't need to do anything specific here
         if self.debug:
-            logger.debug(f'CodePlanner reset for session {state.session_id}')
+            logger.debug(f'BasePlanner reset for session {state.session_id}')
 
         # If we had any internal state to clear, we would do it here
         # For example, clearing conversation history, resetting counters, etc.

--- a/src/codin/host/agent_host.py
+++ b/src/codin/host/agent_host.py
@@ -648,10 +648,10 @@ async def create_agent_host(
             else:
                 # Basic agent - use concrete BaseAgent implementation
                 from ..memory.base import MemMemoryService
-                from ..agent.code_planner import CodePlanner
+                from ..agent.base_planner import BasePlanner
                 
                 # Create a basic planner for the BaseAgent
-                planner = CodePlanner(llm=llm)
+                planner = BasePlanner(llm=llm)
                 
                 agent = BaseAgent(
                     agent_id=agent_id,

--- a/src/codin/host/ray_agent_host.py
+++ b/src/codin/host/ray_agent_host.py
@@ -483,10 +483,10 @@ async def create_ray_agent_host(
 
             # Create a basic agent - use concrete BaseAgent implementation
             from ..memory.base import MemMemoryService
-            from ..agent.code_planner import CodePlanner
+            from ..agent.base_planner import BasePlanner
             
             # Create a basic planner for the BaseAgent
-            planner = CodePlanner(llm=llm)
+            planner = BasePlanner(llm=llm)
             
             agent = BaseAgent(
                 agent_id=agent_id,

--- a/src/codin/prompt/registry.py
+++ b/src/codin/prompt/registry.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """Prompt registry for codin agents.
 
 This module provides a registry system for managing and discovering

--- a/tests/prompt/test_code_agent_loop.py
+++ b/tests/prompt/test_code_agent_loop.py
@@ -1,0 +1,41 @@
+import json
+import pytest
+
+from tests.prompt.test_engine import MockLLM
+import codin.prompt.run as prompt_run_module
+from codin.prompt.run import PromptEngine
+
+@pytest.mark.asyncio
+async def test_code_agent_loop_prompt_with_mock_llm(run_async):
+    llm = MockLLM()
+    llm.response = json.dumps({
+        "thinking": "done",
+        "message": "completed",
+        "tool_calls": [{"name": "tool", "arguments": {"n": i}} for i in range(10)],
+        "task_list": {"completed": [], "pending": []},
+        "should_continue": False
+    })
+
+    prompt_run_module._engine = PromptEngine(llm, endpoint="fs://./prompt_templates")
+
+    variables = {
+        "agent_name": "Agent",
+        "task_id": "t1",
+        "turn_count": 1,
+        "has_tools": False,
+        "tools": [],
+        "has_history": False,
+        "history_text": "",
+        "user_input": "hello",
+        "tool_results": False,
+        "tool_results_text": "",
+        "task_list": {"completed": [], "pending": []},
+        "rules": None,
+    }
+
+    response = await prompt_run_module.prompt_run("code_agent_loop", variables=variables)
+    assert response.content == llm.response
+    data = json.loads(response.content)
+    assert data["message"] == "completed"
+    assert len(data["tool_calls"]) == 10
+    assert data["should_continue"] is False


### PR DESCRIPTION
## Summary
- rename `CodePlanner` module and imports to `BasePlanner`
- adjust agent package lazy import to `get_base_planner`
- allow postponed evaluation in prompt registry
- test running the `code_agent_loop` prompt with `MockLLM`

## Testing
- `pytest tests/prompt/test_code_agent_loop.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6843b479a86c83208e999d9e50f25d79