### PR TITLE
Refactor mailbox implementation

### DIFF
--- a/src/codin/actor/__init__.py
+++ b/src/codin/actor/__init__.py
@@ -6,7 +6,7 @@ and dispatchers for routing requests between agents.
 """
 
 from .dispatcher import DispatchRequest, DispatchResult, Dispatcher, LocalDispatcher
-from .mailbox import AsyncMailbox, LocalAsyncMailbox, Mailbox, MailboxMessage
+from .mailbox import Mailbox, LocalMailbox, RayMailbox
 from .scheduler import ActorInfo, ActorScheduler, LocalActorManager
 from .ray_scheduler import RayActorManager
 
@@ -14,9 +14,8 @@ from .ray_scheduler import RayActorManager
 __all__ = [
     # Mailbox types
     'Mailbox',
-    'AsyncMailbox',
-    'LocalAsyncMailbox',
-    'MailboxMessage',
+    'LocalMailbox',
+    'RayMailbox',
     # Actor manager types
     'ActorScheduler',
     'LocalActorManager',

--- a/src/codin/agent/__init__.py
+++ b/src/codin/agent/__init__.py
@@ -5,9 +5,6 @@ implementations, and supporting types for creating and managing AI agents
 in the codin framework.
 """
 
-# Import existing components
-from ..actor.mailbox import Mailbox
-
 # Import codin architecture components
 from ..memory.base import MemMemoryService, Memory
 from ..model.base import BaseLLM
@@ -91,7 +88,6 @@ __all__ = [
     'MemMemoryService',
     'BaseLLM',
     'Tool',
-    'Mailbox',
     # Lazy access functions
     'get_base_agent',
     'get_base_planner',

--- a/src/codin/agent/base_agent.py
+++ b/src/codin/agent/base_agent.py
@@ -17,7 +17,7 @@ from enum import Enum
 # Import a2a types that we need
 from a2a.types import Role, TextPart
 
-from ..actor.mailbox import LocalAsyncMailbox, Mailbox
+from ..actor.mailbox import LocalMailbox, Mailbox
 from ..memory.base import MemMemoryService, Memory
 from ..model.base import BaseLLM
 from ..tool.base import Tool, ToolContext
@@ -86,7 +86,7 @@ class BaseAgent(Agent):
         self.memory = memory or MemMemoryService()
         self.tools = tools or []
         self.llm = llm
-        self.mailbox = mailbox or LocalAsyncMailbox(self.id)
+        self.mailbox = mailbox or LocalMailbox()
         self.default_config = default_config
         self.debug = debug
 

--- a/src/codin/agent/types.py
+++ b/src/codin/agent/types.py
@@ -76,6 +76,8 @@ class Task(A2ATask):
 class Message(A2AMessage):
     """A2A-compatible message with additional codin features."""
 
+    sender_id: str = ""
+    recipient_ids: list[str] = Field(default_factory=list)
 
 
 class ToolCall(_pyd.BaseModel):

--- a/tests/actor/mailbox_test.py
+++ b/tests/actor/mailbox_test.py
@@ -7,17 +7,21 @@ from datetime import datetime
 from a2a.types import Message, Role, TextPart
 
 from codin.actor import (
-    Mailbox, LocalAsyncMailbox, MailboxMessage,
-    ActorScheduler, LocalActorManager, ActorInfo,
-    Dispatcher, LocalDispatcher
+    Mailbox,
+    LocalMailbox,
+    ActorScheduler,
+    LocalActorManager,
+    ActorInfo,
+    Dispatcher,
+    LocalDispatcher,
 )
 from codin.agent.types import ControlSignal, RunnerControl, RunnerInput
 
 
 @pytest.mark.asyncio
-async def test_local_async_mailbox():
-    """Test the LocalAsyncMailbox implementation."""
-    mailbox = LocalAsyncMailbox("test_agent", maxsize=10)
+async def test_local_mailbox():
+    """Test the LocalMailbox implementation."""
+    mailbox = LocalMailbox(maxsize=10)
     
     # Test basic inbox/outbox operations
     msg1 = Message(
@@ -32,7 +36,7 @@ async def test_local_async_mailbox():
     await mailbox.put_inbox(msg1)
     
     # Get message from inbox
-    received = await mailbox.get_inbox(timeout=1.0)
+    received = (await mailbox.get_inbox(timeout=1.0))[0]
     assert received.messageId == "msg1"
     assert received.parts[0].root.text == "Hello"
     
@@ -46,7 +50,7 @@ async def test_local_async_mailbox():
     )
     
     await mailbox.put_outbox(msg2)
-    received_out = await mailbox.get_outbox(timeout=1.0)
+    received_out = (await mailbox.get_outbox(timeout=1.0))[0]
     assert received_out.messageId == "msg2"
 
 
@@ -163,7 +167,7 @@ async def test_control_signals():
 @pytest.mark.asyncio
 async def test_mailbox_timeout():
     """Test mailbox timeout behavior."""
-    mailbox = LocalAsyncMailbox("test_agent")
+    mailbox = LocalMailbox()
     
     # Test timeout on empty inbox
     with pytest.raises(asyncio.TimeoutError):
@@ -177,7 +181,7 @@ async def test_mailbox_timeout():
 @pytest.mark.asyncio
 async def test_mailbox_subscription():
     """Test mailbox subscription patterns."""
-    mailbox = LocalAsyncMailbox("test_agent")
+    mailbox = LocalMailbox()
     
     # Put a message in inbox
     msg = Message(

--- a/tests/actor/ray_mailbox_test.py
+++ b/tests/actor/ray_mailbox_test.py
@@ -1,0 +1,24 @@
+import pytest
+from a2a.types import Message, Role, TextPart
+
+from codin.actor.mailbox import RayMailbox
+
+
+@pytest.mark.asyncio
+async def test_ray_mailbox_basic():
+    ray = pytest.importorskip("ray")
+    ray.init(local_mode=True, ignore_reinit_error=True)
+
+    mailbox = RayMailbox("agent1", maxsize=10)
+    msg = Message(
+        messageId="m1",
+        role=Role.user,
+        parts=[TextPart(text="hi")],
+        contextId="ctx",
+        kind="message",
+    )
+    await mailbox.put_inbox(msg)
+    received = (await mailbox.get_inbox(timeout=1.0))[0]
+    assert received.messageId == "m1"
+
+    ray.shutdown()


### PR DESCRIPTION
## Summary
- redesign mailbox system to use new `Message` structure
- implement `LocalMailbox` and `RayMailbox`
- update agent base to use `LocalMailbox`
- adjust public exports
- add unit tests for new mailboxes

## Testing
- `pytest tests/actor/mailbox_test.py::test_local_mailbox tests/actor/ray_mailbox_test.py::test_ray_mailbox_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d7c4fe9083209fb33c754a9823c2