### PR TITLE
Split mailbox implementations

### DIFF
--- a/src/codin/actor/local_mailbox.py
+++ b/src/codin/actor/local_mailbox.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import typing as _t
+
+from .mailbox import Mailbox
+from ..agent.types import Message
+
+__all__ = ["LocalMailbox"]
+
+
+class LocalMailbox(Mailbox):
+    """Local asyncio based mailbox."""
+
+    def __init__(self, maxsize: int = 100):
+        self._inbox: asyncio.Queue[Message] = asyncio.Queue(maxsize=maxsize)
+        self._outbox: asyncio.Queue[Message] = asyncio.Queue(maxsize=maxsize)
+
+    async def _put(
+        self, q: asyncio.Queue[Message], msgs: Message | list[Message], timeout: float | None
+    ) -> None:
+        if not isinstance(msgs, list):
+            msgs = [msgs]
+        for msg in msgs:
+            if timeout is None:
+                while not q.empty():
+                    await asyncio.sleep(0)
+                await q.put(msg)
+            else:
+                await asyncio.wait_for(q.put(msg), timeout=timeout)
+
+    async def put_inbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
+        await self._put(self._inbox, msgs, timeout)
+
+    async def put_outbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
+        await self._put(self._outbox, msgs, timeout)
+
+    async def _get(
+        self, q: asyncio.Queue[Message], max_messages: int, timeout: float | None
+    ) -> list[Message]:
+        msgs: list[Message] = []
+        for _ in range(max_messages):
+            msg = await asyncio.wait_for(q.get(), timeout=timeout)
+            msgs.append(msg)
+        return msgs
+
+    async def get_inbox(
+        self, max_messages: int = 1, timeout: float | None = None
+    ) -> list[Message]:
+        return await self._get(self._inbox, max_messages, timeout)
+
+    async def get_outbox(
+        self, max_messages: int = 1, timeout: float | None = None
+    ) -> list[Message]:
+        return await self._get(self._outbox, max_messages, timeout)
+
+    async def subscribe_inbox(self) -> _t.AsyncIterator[Message]:
+        while True:
+            msg = await self._inbox.get()
+            yield msg
+
+    async def subscribe_outbox(self) -> _t.AsyncIterator[Message]:
+        while True:
+            msg = await self._outbox.get()
+            yield msg

--- a/src/codin/actor/mailbox.py
+++ b/src/codin/actor/mailbox.py
@@ -1,4 +1,4 @@
-"""Mailbox implementations for inter-agent communication."""
+"""Mailbox protocol for inter-agent communication."""
 
 from __future__ import annotations
 
@@ -7,11 +7,6 @@ import typing as _t
 from abc import ABC, abstractmethod
 
 from ..agent.types import Message
-
-try:  # pragma: no cover - optional dependency
-    import ray
-except Exception:  # pragma: no cover
-    ray = None
 
 
 __all__ = ["Mailbox", "LocalMailbox", "RayMailbox"]
@@ -53,156 +48,6 @@ class Mailbox(ABC):
         """Iterate over outbox messages."""
 
 
-class LocalMailbox(Mailbox):
-    """Local asyncio based mailbox."""
-
-    def __init__(self, maxsize: int = 100):
-        self._inbox: asyncio.Queue[Message] = asyncio.Queue(maxsize=maxsize)
-        self._outbox: asyncio.Queue[Message] = asyncio.Queue(maxsize=maxsize)
-
-    async def _put(
-        self, q: asyncio.Queue[Message], msgs: Message | list[Message], timeout: float | None
-    ) -> None:
-        if not isinstance(msgs, list):
-            msgs = [msgs]
-        for msg in msgs:
-            if timeout is None:
-                while not q.empty():
-                    await asyncio.sleep(0)
-                await q.put(msg)
-            else:
-                await asyncio.wait_for(q.put(msg), timeout=timeout)
-
-    async def put_inbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
-        await self._put(self._inbox, msgs, timeout)
-
-    async def put_outbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
-        await self._put(self._outbox, msgs, timeout)
-
-    async def _get(
-        self, q: asyncio.Queue[Message], max_messages: int, timeout: float | None
-    ) -> list[Message]:
-        msgs: list[Message] = []
-        for _ in range(max_messages):
-            msg = await asyncio.wait_for(q.get(), timeout=timeout)
-            msgs.append(msg)
-        return msgs
-
-    async def get_inbox(
-        self, max_messages: int = 1, timeout: float | None = None
-    ) -> list[Message]:
-        return await self._get(self._inbox, max_messages, timeout)
-
-    async def get_outbox(
-        self, max_messages: int = 1, timeout: float | None = None
-    ) -> list[Message]:
-        return await self._get(self._outbox, max_messages, timeout)
-
-    async def subscribe_inbox(self) -> _t.AsyncIterator[Message]:
-        while True:
-            msg = await self._inbox.get()
-            yield msg
-
-    async def subscribe_outbox(self) -> _t.AsyncIterator[Message]:
-        while True:
-            msg = await self._outbox.get()
-            yield msg
-
-
-if ray:  # pragma: no cover - avoid ray when not installed
-
-    @ray.remote
-    class _MailboxActor:
-        def __init__(self, maxsize: int = 100):
-            self._inbox: asyncio.Queue[Message] = asyncio.Queue(maxsize=maxsize)
-            self._outbox: asyncio.Queue[Message] = asyncio.Queue(maxsize=maxsize)
-
-        async def put_inbox(self, msgs: list[Message]):
-            for m in msgs:
-                await self._inbox.put(m)
-
-        async def put_outbox(self, msgs: list[Message]):
-            for m in msgs:
-                await self._outbox.put(m)
-
-        async def get_inbox(self, n: int, timeout: float | None):
-            res = []
-            for _ in range(n):
-                res.append(await asyncio.wait_for(self._inbox.get(), timeout=timeout))
-            return res
-
-        async def get_outbox(self, n: int, timeout: float | None):
-            res = []
-            for _ in range(n):
-                res.append(await asyncio.wait_for(self._outbox.get(), timeout=timeout))
-            return res
-
-    class RayMailbox(Mailbox):
-        """Mailbox backed by a Ray actor."""
-
-        def __init__(self, agent_id: str, maxsize: int = 100):
-            if ray is None:
-                raise ImportError("ray is required for RayMailbox")
-            self._actor = _MailboxActor.options(name=None).remote(maxsize)
-            self.agent_id = agent_id
-
-        async def put_inbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
-            if not isinstance(msgs, list):
-                msgs = [msgs]
-            await self._actor.put_inbox.remote(msgs)
-
-        async def put_outbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
-            if not isinstance(msgs, list):
-                msgs = [msgs]
-            await self._actor.put_outbox.remote(msgs)
-
-        async def get_inbox(
-            self, max_messages: int = 1, timeout: float | None = None
-        ) -> list[Message]:
-            return await self._actor.get_inbox.remote(max_messages, timeout)
-
-        async def get_outbox(
-            self, max_messages: int = 1, timeout: float | None = None
-        ) -> list[Message]:
-            return await self._actor.get_outbox.remote(max_messages, timeout)
-
-        async def subscribe_inbox(self) -> _t.AsyncIterator[Message]:
-            while True:
-                msgs = await self.get_inbox()
-                for m in msgs:
-                    yield m
-
-        async def subscribe_outbox(self) -> _t.AsyncIterator[Message]:
-            while True:
-                msgs = await self.get_outbox()
-                for m in msgs:
-                    yield m
-
-else:  # pragma: no cover - provide stub
-
-    class RayMailbox(Mailbox):
-        def __init__(self, *a, **k):
-            raise ImportError("ray is required for RayMailbox")
-
-        async def put_inbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
-            raise NotImplementedError()
-
-        async def put_outbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
-            raise NotImplementedError()
-
-        async def get_inbox(
-            self, max_messages: int = 1, timeout: float | None = None
-        ) -> list[Message]:
-            raise NotImplementedError()
-
-        async def get_outbox(
-            self, max_messages: int = 1, timeout: float | None = None
-        ) -> list[Message]:
-            raise NotImplementedError()
-
-        async def subscribe_inbox(self) -> _t.AsyncIterator[Message]:
-            raise NotImplementedError()
-
-        async def subscribe_outbox(self) -> _t.AsyncIterator[Message]:
-            raise NotImplementedError()
+from .local_mailbox import LocalMailbox
+from .ray_mailbox import RayMailbox
 

--- a/src/codin/actor/ray_mailbox.py
+++ b/src/codin/actor/ray_mailbox.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import asyncio
+import typing as _t
+
+from .mailbox import Mailbox
+from ..agent.types import Message
+
+try:  # pragma: no cover - optional dependency
+    import ray
+except Exception:  # pragma: no cover
+    ray = None
+
+__all__ = ["RayMailbox"]
+
+
+if ray:  # pragma: no cover - avoid ray when not installed
+
+    @ray.remote
+    class _MailboxActor:
+        def __init__(self, maxsize: int = 100):
+            self._inbox: asyncio.Queue[Message] = asyncio.Queue(maxsize=maxsize)
+            self._outbox: asyncio.Queue[Message] = asyncio.Queue(maxsize=maxsize)
+
+        async def put_inbox(self, msgs: list[Message]):
+            for m in msgs:
+                await self._inbox.put(m)
+
+        async def put_outbox(self, msgs: list[Message]):
+            for m in msgs:
+                await self._outbox.put(m)
+
+        async def get_inbox(self, n: int, timeout: float | None):
+            res = []
+            for _ in range(n):
+                res.append(await asyncio.wait_for(self._inbox.get(), timeout=timeout))
+            return res
+
+        async def get_outbox(self, n: int, timeout: float | None):
+            res = []
+            for _ in range(n):
+                res.append(await asyncio.wait_for(self._outbox.get(), timeout=timeout))
+            return res
+
+    class RayMailbox(Mailbox):
+        """Mailbox backed by a Ray actor."""
+
+        def __init__(self, agent_id: str, maxsize: int = 100):
+            if ray is None:
+                raise ImportError("ray is required for RayMailbox")
+            self._actor = _MailboxActor.options(name=None).remote(maxsize)
+            self.agent_id = agent_id
+
+        async def put_inbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
+            if not isinstance(msgs, list):
+                msgs = [msgs]
+            await self._actor.put_inbox.remote(msgs)
+
+        async def put_outbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
+            if not isinstance(msgs, list):
+                msgs = [msgs]
+            await self._actor.put_outbox.remote(msgs)
+
+        async def get_inbox(
+            self, max_messages: int = 1, timeout: float | None = None
+        ) -> list[Message]:
+            return await self._actor.get_inbox.remote(max_messages, timeout)
+
+        async def get_outbox(
+            self, max_messages: int = 1, timeout: float | None = None
+        ) -> list[Message]:
+            return await self._actor.get_outbox.remote(max_messages, timeout)
+
+        async def subscribe_inbox(self) -> _t.AsyncIterator[Message]:
+            while True:
+                msgs = await self.get_inbox()
+                for m in msgs:
+                    yield m
+
+        async def subscribe_outbox(self) -> _t.AsyncIterator[Message]:
+            while True:
+                msgs = await self.get_outbox()
+                for m in msgs:
+                    yield m
+
+else:  # pragma: no cover - provide stub
+
+    class RayMailbox(Mailbox):
+        def __init__(self, *a, **k):
+            raise ImportError("ray is required for RayMailbox")
+
+        async def put_inbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
+            raise NotImplementedError()
+
+        async def put_outbox(self, msgs: Message | list[Message], timeout: float | None = None) -> None:
+            raise NotImplementedError()
+
+        async def get_inbox(
+            self, max_messages: int = 1, timeout: float | None = None
+        ) -> list[Message]:
+            raise NotImplementedError()
+
+        async def get_outbox(
+            self, max_messages: int = 1, timeout: float | None = None
+        ) -> list[Message]:
+            raise NotImplementedError()
+
+        async def subscribe_inbox(self) -> _t.AsyncIterator[Message]:
+            raise NotImplementedError()
+
+        async def subscribe_outbox(self) -> _t.AsyncIterator[Message]:
+            raise NotImplementedError()


### PR DESCRIPTION
## Summary
- split `LocalMailbox` and `RayMailbox` into dedicated modules
- keep `Mailbox` base class in `mailbox.py`

## Testing
- `pytest -q` *(fails: AttributeError in agent tests)*

------
https://chatgpt.com/codex/tasks/task_e_6843dbf1adec83209424580fee0a1ff9