### PR TITLE
Implement ErrorStep and planner refactor

### DIFF
--- a/src/codin/id.py
+++ b/src/codin/id.py
@@ -5,16 +5,25 @@ with customizable prefixes and lengths.
 """
 
 
-def new_id(prefix: str, length: int = 8) -> str:
-    """Create a random prefix of specified length using alphanumeric characters.
+def new_id(prefix: str, length: int = 8, uuid: bool = False) -> str:
+    """Create an ID with the given prefix.
 
     Args:
-        length: Length of the prefix to generate. Defaults to 8.
+        length: Length of the random segment if ``uuid`` is ``False``.
+        uuid: Generate a UUID4 segment when ``True``. Defaults to ``False``.
 
     Returns:
-        A random string of alphanumeric characters of specified length.
+        A string identifier prefixed by ``prefix``.
     """
     import random
     import string
+    import uuid as _uuid
 
-    return f'{prefix}-{"".join(random.choices(string.ascii_letters + string.digits, k=length))}'
+    if uuid:
+        suffix = str(_uuid.uuid4())
+    else:
+        suffix = "".join(
+            random.choices(string.ascii_letters + string.digits, k=length)
+        )
+
+    return f"{prefix}-{suffix}"

--- a/tests/agent/test_base_planner.py
+++ b/tests/agent/test_base_planner.py
@@ -1,0 +1,21 @@
+import pytest
+
+from codin.agent.base_planner import BasePlanner
+from codin.agent.types import ErrorStep, FinishStep, State
+
+ErrorStep.model_rebuild()
+
+
+@pytest.mark.asyncio
+async def test_error_step_emitted(monkeypatch):
+    async def fail_prompt_run(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("codin.agent.base_planner.prompt_run", fail_prompt_run)
+
+    planner = BasePlanner()
+    state = State.model_construct(session_id="s2")
+
+    steps = [step async for step in planner.next(state)]
+    assert isinstance(steps[0], ErrorStep)
+    assert isinstance(steps[1], FinishStep)


### PR DESCRIPTION
## Summary
- remove `BasePlannerConfig` and use `State.model_config`
- refactor `BasePlanner` initialization parameters and logging
- use new `new_id` helper for tool-call steps
- extend `State` with `model_config_dict`
- add tests for planner error handling

## Testing
- `pytest tests/agent/test_base_planner.py::test_error_step_emitted -q`
- `pytest -q` *(fails: 28 failed, 174 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6843db578aac832095f42cdf3bf13e39