### PR TITLE
Add file-based replay logging

### DIFF
--- a/src/codin/replay/__init__.py
+++ b/src/codin/replay/__init__.py
@@ -7,8 +7,10 @@ by examining past execution patterns and behaviors.
 """
 
 from .base import ReplayService
+from .file import FileReplayService
 
 
 __all__ = [
-    'ReplayService',
+    "ReplayService",
+    "FileReplayService",
 ]

--- a/src/codin/replay/file.py
+++ b/src/codin/replay/file.py
@@ -1,0 +1,75 @@
+"""File-based replay service for persisting execution logs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import typing as _t
+
+from .base import ReplayService
+
+
+@dataclass
+class _Writer:
+    queue: asyncio.Queue[str]
+    task: asyncio.Task
+    file: _t.TextIO
+
+
+class FileReplayService(ReplayService):
+    """Replay service that persists logs to JSONL files on disk."""
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        super().__init__()
+        self._base_dir = Path(base_dir or Path.home() / ".codin") / "sessions"
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+        self._writers: dict[str, _Writer] = {}
+
+    async def record_step(self, session_id: str, step: _t.Any, result: _t.Any) -> None:
+        await super().record_step(session_id, step, result)
+        entry = self._replay_logs[session_id][-1]
+        writer = await self._ensure_writer(session_id)
+        await writer.queue.put(json.dumps(entry))
+
+    async def cleanup(self) -> None:
+        """Flush and close all session writers."""
+        for writer in self._writers.values():
+            await writer.queue.put(None)  # type: ignore[arg-type]
+            await writer.task
+        self._writers.clear()
+
+    async def _ensure_writer(self, session_id: str) -> _Writer:
+        if session_id in self._writers:
+            return self._writers[session_id]
+
+        timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+        filename = f"replay-{timestamp}-{session_id}.jsonl"
+        path = self._base_dir / filename
+        file = open(path, "a", encoding="utf-8")
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=256)
+
+        async def writer_loop() -> None:
+            while True:
+                line = await queue.get()
+                if line is None:
+                    break
+                await asyncio.to_thread(file.write, line + "\n")
+                await asyncio.to_thread(file.flush)
+            file.close()
+
+        task = asyncio.create_task(writer_loop())
+        writer = _Writer(queue=queue, task=task, file=file)
+        self._writers[session_id] = writer
+
+        meta = {
+            "id": session_id,
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+        }
+        await queue.put(json.dumps(meta))
+        return writer
+
+
+__all__ = ["FileReplayService"]

--- a/tests/test_file_replay_service.py
+++ b/tests/test_file_replay_service.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import asyncio
+import json
+
+
+import pytest
+
+from codin.replay.file import FileReplayService
+
+
+class DummyStep:
+    def __init__(self, step_id="step1", step_type="typeA"):
+        self.step_id = step_id
+        self.step_type = step_type
+
+    def __str__(self) -> str:
+        return f"DummyStep({self.step_id}, {self.step_type})"
+
+
+class DummyResult:
+    def __init__(self, value="result1"):
+        self.value = value
+
+    def __str__(self) -> str:
+        return f"DummyResult({self.value})"
+
+
+def test_file_replay_service_writes(tmp_path: Path):
+    session_id = "test_session"
+
+    async def _run():
+        service = FileReplayService(base_dir=tmp_path)
+
+        await service.record_step(session_id, DummyStep(), DummyResult())
+        await service.cleanup()
+
+    asyncio.run(_run())
+
+    files = list((tmp_path / "sessions").glob(f"replay-*{session_id}.jsonl"))
+    assert len(files) == 1
+
+    lines = files[0].read_text().splitlines()
+    assert len(lines) == 2
+
+    meta = json.loads(lines[0])
+    assert meta["id"] == session_id
+
+    entry = json.loads(lines[1])
+    assert entry["step_id"] == "step1"
+    assert entry["step_type"] == "typeA"


### PR DESCRIPTION
## Summary
- implement `FileReplayService` to write replay JSONL logs
- expose the new class in the replay package
- test writing a replay file
- fix the async test to run without `pytest-asyncio`

## Testing
- `pytest -q tests/test_file_replay_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6843e4a5351c8320b156aee632dcd0bd