### PR TITLE
Add environment policy support for sandboxes

### DIFF
--- a/src/codin/sandbox/codex.py
+++ b/src/codin/sandbox/codex.py
@@ -8,7 +8,7 @@ import typing as _t
 
 from pathlib import Path
 
-from .base import ExecResult, Sandbox
+from .base import ExecResult, Sandbox, ShellEnvironmentPolicy
 
 
 __all__ = ['CodexSandbox']
@@ -17,8 +17,8 @@ __all__ = ['CodexSandbox']
 class CodexSandbox(Sandbox):
     """Codex CLI sandbox wrapper (TODO)."""
 
-    def __init__(self, **_kwargs):
-        super().__init__()
+    def __init__(self, *, env_policy: ShellEnvironmentPolicy | None = None, **_kwargs):
+        super().__init__(env_policy=env_policy)
         raise NotImplementedError('CodexSandbox is not yet implemented. Contributions welcome!')
 
     async def _up(self) -> None:

--- a/src/codin/sandbox/daytona.py
+++ b/src/codin/sandbox/daytona.py
@@ -13,7 +13,7 @@ import zipfile
 
 from pathlib import Path
 
-from .base import ExecResult, Sandbox
+from .base import ExecResult, Sandbox, ShellEnvironmentPolicy
 
 
 __all__ = ['DaytonaSandbox']
@@ -29,8 +29,8 @@ class DaytonaSandbox(Sandbox):
 
     BASE_URL = 'https://runner.api.daytona.io'  # TODO: make configurable
 
-    def __init__(self, workspace_id: str | None = None, api_key: str | None = None):
-        super().__init__()
+    def __init__(self, workspace_id: str | None = None, api_key: str | None = None, *, env_policy: ShellEnvironmentPolicy | None = None):
+        super().__init__(env_policy=env_policy)
         import os
 
         import requests
@@ -191,8 +191,9 @@ class DaytonaSandbox(Sandbox):
         payload: dict[str, _t.Any] = {'cmd': cmd_str}
         if cwd:
             payload['cwd'] = cwd
-        if env:
-            payload['envs'] = env
+        env_map = self._prepare_env(env)
+        if env_map:
+            payload['envs'] = env_map
         if timeout:
             payload['timeout'] = int(timeout)
 

--- a/src/codin/sandbox/e2b.py
+++ b/src/codin/sandbox/e2b.py
@@ -12,7 +12,7 @@ import zipfile
 
 from pathlib import Path
 
-from .base import ExecResult, Sandbox
+from .base import ExecResult, Sandbox, ShellEnvironmentPolicy
 
 
 __all__ = ['E2BSandbox']
@@ -21,8 +21,8 @@ __all__ = ['E2BSandbox']
 class E2BSandbox(Sandbox):
     """Adapter around E2B cloud sandbox SDK."""
 
-    def __init__(self, **kwargs):
-        super().__init__()
+    def __init__(self, *, env_policy: ShellEnvironmentPolicy | None = None, **kwargs):
+        super().__init__(env_policy=env_policy)
         try:
             from e2b import Sandbox as _E2B
         except ImportError as e:  # pragma: no cover
@@ -143,7 +143,7 @@ class E2BSandbox(Sandbox):
             result = self._sandbox.commands.run(
                 cmd_str,
                 cwd=cwd,
-                envs=env,
+                envs=self._prepare_env(env),
                 timeout=timeout,
             )
             return ExecResult(result.stdout, result.stderr, result.exit_code)

--- a/src/codin/sandbox/local.py
+++ b/src/codin/sandbox/local.py
@@ -17,7 +17,7 @@ import zipfile
 
 from pathlib import Path
 
-from .base import ExecResult, Sandbox
+from .base import ExecResult, Sandbox, ShellEnvironmentPolicy
 
 
 __all__ = ['LocalSandbox']
@@ -32,8 +32,8 @@ class LocalSandbox(Sandbox):
     Enhanced to support both Windows PowerShell and Unix bash automatically.
     """
 
-    def __init__(self, workdir: str | None = None):
-        super().__init__()
+    def __init__(self, workdir: str | None = None, *, env_policy: ShellEnvironmentPolicy | None = None):
+        super().__init__(env_policy=env_policy)
         self._workdir = workdir or os.getcwd()
         self._is_windows = platform.system().lower() == 'windows'
         self._shell_executable = self._detect_shell()
@@ -172,7 +172,7 @@ class LocalSandbox(Sandbox):
 
         def _run_subprocess():
             # Set up environment with UTF-8 encoding for Windows
-            subprocess_env = {**os.environ, **(env or {})}
+            subprocess_env = self._prepare_env(env)
             if self._is_windows:
                 # Force UTF-8 encoding on Windows
                 subprocess_env['PYTHONIOENCODING'] = 'utf-8'


### PR DESCRIPTION
## Summary
- add environment variable filtering utilities
- create helper to derive env maps
- support ShellEnvironmentPolicy in sandbox base class
- apply policy to local, e2b, daytona and codex sandboxes

## Testing
- `pip install -e .`
- `pytest -q` *(fails: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68441a58d5788320a865b1d9a57c1d45