### PR TITLE
Add API controller and fix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "beautifulsoup4>=4.9.0",
     "numpy>=1.24.0",
     "lancedb>=0.4.7",
+    "fastapi>=0.110.0",
 ]
 
 [project.scripts]

--- a/src/codin/agent/types.py
+++ b/src/codin/agent/types.py
@@ -1,5 +1,7 @@
 """Type definitions for agent system."""
 
+from __future__ import annotations
+
 import typing as _t
 
 from datetime import datetime
@@ -15,13 +17,15 @@ from a2a.types import (
     TaskArtifactUpdateEvent,
     TaskStatusUpdateEvent,
     TextPart,
+    DataPart,
+    FilePart,
 )
 
 # Re-export core A2A types for compatibility
 from a2a.types import (
     Task as A2ATask,
 )
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 if _t.TYPE_CHECKING:
@@ -79,6 +83,40 @@ class Message(A2AMessage):
 
     sender_id: str = ""
     recipient_ids: list[str] = Field(default_factory=list)
+    parts: list[_t.Union[TextPart, FilePart, DataPart, "ToolUsePart"]]
+
+    def add_text_part(self, text: str, metadata: dict[str, _t.Any] | None = None) -> None:
+        """Convenience helper to append a TextPart."""
+        self.parts.append(TextPart(text=text, metadata=metadata))
+
+    def add_data_part(self, data: dict[str, _t.Any], metadata: dict[str, _t.Any] | None = None) -> None:
+        """Convenience helper to append a DataPart."""
+        from a2a.types import DataPart
+
+        self.parts.append(DataPart(data=data, metadata=metadata))
+
+    def add_tool_call_part(self, call: "ToolCall") -> None:
+        """Append a tool call as a ToolUsePart."""
+        self.parts.append(
+            ToolUsePart(
+                type="call",
+                id=call.call_id,
+                name=call.name,
+                input=call.arguments,
+            )
+        )
+
+    def add_tool_result_part(self, result: "ToolCallResult", name: str) -> None:
+        """Append a tool result as a ToolUsePart."""
+        self.parts.append(
+            ToolUsePart(
+                type="result",
+                id=result.call_id,
+                name=name,
+                output=result.output,
+                metadata={"error": result.error} if result.error else None,
+            )
+        )
 
 
 class ToolCall(_pyd.BaseModel):
@@ -376,7 +414,53 @@ class Step(BaseModel):
     # Content fields - can contain multiple types
     message: Message | None = None  # A2A Message content
     event: Event | None = None  # A2A Event or Internal Event content
+    tool_call: ToolUsePart | ToolCall | None = None
+    tool_call_result: ToolUsePart | ToolCallResult | None = None
     thinking: str | None = None  # Internal reasoning
+
+    # ------------------------------------------------------------------
+    # Content helpers
+    # ------------------------------------------------------------------
+
+    def has_message_content(self) -> bool:
+        """Return True if this step contains message content."""
+        return self.message is not None or getattr(self, "final_message", None) is not None
+
+    def has_event_content(self) -> bool:
+        """Return True if this step contains an event."""
+        return self.event is not None
+
+    def has_tool_content(self) -> bool:
+        """Return True if this step relates to tool usage."""
+        if isinstance(self, ToolCallStep):
+            return self.tool_call is not None or self.tool_call_result is not None
+        if getattr(self, "tool_call", None) is not None or getattr(self, "tool_call_result", None) is not None:
+            return True
+        if self.message:
+            return any(getattr(p, "kind", None) == "tool-use" for p in self.message.parts)
+        return False
+
+    def get_content_types(self) -> list[str]:
+        """Return a list of content types present on this step."""
+        types: list[str] = []
+        if self.has_message_content():
+            types.append("message")
+        if self.has_event_content():
+            types.append("event")
+        if self.thinking:
+            types.append("thinking")
+        if self.has_tool_content():
+            if "tool" not in types:
+                types.append("tool")
+        return types
+
+    def is_a2a_event(self) -> bool:
+        """Return True if the event is an A2A event."""
+        return isinstance(self.event, (TaskStatusUpdateEvent, TaskArtifactUpdateEvent))
+
+    def is_internal_event(self) -> bool:
+        """Return True if the event is an internal RunEvent."""
+        return isinstance(self.event, RunEvent)
 
 
 class MessageStep(Step):
@@ -385,7 +469,7 @@ class MessageStep(Step):
     is_streaming: bool = False
     step_type: StepType = StepType.MESSAGE
 
-    def __post_init__(self):
+    def model_post_init(self, __context: _t.Any) -> None:
         if self.message is None:
             raise ValueError('message is required for MessageStep')
 
@@ -410,12 +494,50 @@ class ToolCallStep(Step):
     step_type: StepType = StepType.TOOL_CALL
     tool_call: ToolUsePart | None = None
     tool_call_result: ToolUsePart | None = None
+    success: bool = True
 
-    def __post_init__(self):
+    @model_validator(mode="before")
+    @classmethod
+    def _convert_calls(cls, data: dict[str, _t.Any]) -> dict[str, _t.Any]:
+        call = data.get("tool_call")
+        if isinstance(call, ToolCall):
+            data["tool_call"] = ToolUsePart(
+                type="call",
+                id=call.call_id,
+                name=call.name,
+                input=call.arguments,
+            )
+        result = data.get("tool_call_result")
+        if isinstance(result, ToolCallResult):
+            data["tool_call_result"] = ToolUsePart(
+                type="result",
+                id=result.call_id,
+                name=call.name if call else "",
+                output=result.output,
+                metadata={"error": result.error} if result.error else None,
+            )
+        return data
+
+    def model_post_init(self, __context: _t.Any) -> None:
         if self.tool_call is None:
             raise ValueError("tool_call (ToolUsePart type='call') is required for ToolCallStep")
         if self.tool_call.type != 'call':
             raise ValueError("ToolCallStep.tool_call must be a ToolUsePart with type='call'")
+
+    def add_result(self, result: ToolCallResult) -> None:
+        """Attach a ToolCallResult to this step and update success."""
+        self.tool_call_result = ToolUsePart(
+            type="result",
+            id=result.call_id,
+            name=self.tool_call.name if self.tool_call else "",
+            output=result.output,
+            metadata={"error": result.error} if result.error else None,
+        )
+        self.success = result.success
+
+    def to_message_parts(self) -> tuple[ToolUsePart, ToolUsePart | None]:
+        """Return tool call and result parts for message conversion."""
+        return self.tool_call, self.tool_call_result
 
 
 class EventStep(Step):
@@ -423,7 +545,7 @@ class EventStep(Step):
 
     step_type: StepType = StepType.EVENT
 
-    def __post_init__(self):
+    def model_post_init(self, __context: _t.Any) -> None:
         if self.event is None:
             raise ValueError('event is required for EventStep')
 
@@ -433,7 +555,7 @@ class ThinkStep(Step):
 
     step_type: StepType = StepType.THINK
 
-    def __post_init__(self):
+    def model_post_init(self, __context: _t.Any) -> None:
         if self.thinking is None:
             self.thinking = ''
 
@@ -447,19 +569,21 @@ class FinishStep(Step):
     success: bool = True
     task: Task | None = None
 
-    def __post_init__(self):
+    def model_post_init(self, __context: _t.Any) -> None:
         if self.reason is None:
             self.reason = 'Task completed'
         # Only create a message if none is provided and we have a reason
         if self.message is None and self.final_message is None and self.reason:
             # Create a simple message for the finish step
-            self.final_message = Message(
+            msg = Message(
                 messageId=f'finish-{self.step_id}',
                 role=Role.agent,
                 parts=[TextPart(text=self.reason)],
                 contextId=None,
                 kind='message',
             )
+            self.message = msg
+            self.final_message = msg
 
     def create_completion_event(self, task_id: str, context_id: str) -> TaskStatusUpdateEvent:
         """Create a task completion event."""

--- a/src/codin/api/__init__.py
+++ b/src/codin/api/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI controllers for the codin dispatcher."""
+
+from .app import create_app, app
+
+__all__ = ["create_app", "app"]

--- a/src/codin/api/app.py
+++ b/src/codin/api/app.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import typing as _t
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from ..actor import LocalActorManager, LocalDispatcher, Dispatcher
+
+
+class SubmitRequest(BaseModel):
+    a2a_request: dict[str, _t.Any]
+
+
+class SubmitResponse(BaseModel):
+    runner_id: str
+
+
+class SignalRequest(BaseModel):
+    ctrl: str
+
+
+async def _sse_stream(queue: asyncio.Queue) -> _t.AsyncIterator[str]:
+    while True:
+        item = await queue.get()
+        if item is None:
+            break
+        data = json.dumps(item)
+        yield f"data: {data}\n\n"
+
+
+def create_app(dispatcher: Dispatcher | None = None) -> FastAPI:
+    dispatcher = dispatcher or LocalDispatcher(LocalActorManager())
+    app = FastAPI()
+
+    @app.post("/v1/submit", response_model=SubmitResponse)
+    async def submit(req: SubmitRequest) -> SubmitResponse:
+        runner_id = await dispatcher.submit(req.a2a_request)
+        return SubmitResponse(runner_id=runner_id)
+
+    @app.post("/v1/signal/{agent_id}")
+    async def signal(agent_id: str, req: SignalRequest) -> dict[str, str]:
+        await dispatcher.signal(agent_id, req.ctrl)
+        return {"status": "ok"}
+
+    @app.get("/v1/status/{runner_id}")
+    async def status(runner_id: str):
+        result = await dispatcher.get_status(runner_id)
+        if result is None:
+            raise HTTPException(status_code=404, detail="runner not found")
+        return result
+
+    @app.get("/v1/stream/{runner_id}")
+    async def stream(runner_id: str):
+        queue = dispatcher.get_stream_queue(runner_id)
+        if queue is None:
+            raise HTTPException(status_code=404, detail="runner not found")
+        return StreamingResponse(_sse_stream(queue), media_type="text/event-stream")
+
+    return app
+
+
+# Convenience application for `uvicorn codin.api.app:app`
+dispatcher = LocalDispatcher(LocalActorManager())
+app = create_app(dispatcher)

--- a/src/codin/config.py
+++ b/src/codin/config.py
@@ -441,6 +441,12 @@ def get_config(config_file: Path | str | None = None) -> CodinConfig:
         _config = load_config(config_file)
         _config_file = config_file
 
+    # Apply environment overrides on each call
+    if "LLM_MODEL" in os.environ:
+        _config.model = os.environ["LLM_MODEL"]
+    if "LLM_PROVIDER" in os.environ:
+        _config.provider = os.environ["LLM_PROVIDER"]
+
     return _config
 
 

--- a/src/codin/tool/base.py
+++ b/src/codin/tool/base.py
@@ -27,12 +27,32 @@ __all__ = [
 class ToolDefinition(BaseModel):
     """Tool definition for LLM function calling."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict()
 
     name: str
     description: str
     parameters: dict[str, _t.Any]
     metadata: dict[str, _t.Any] | None = None
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        parameters: dict[str, _t.Any],
+        metadata: dict[str, _t.Any] | None = None,
+    ) -> None:
+        super().__init__(
+            name=name,
+            description=description,
+            parameters=parameters,
+            metadata=metadata,
+        )
+        object.__setattr__(self, "_frozen", True)
+
+    def __setattr__(self, name: str, value: _t.Any) -> None:
+        if getattr(self, "_frozen", False):
+            raise AttributeError("ToolDefinition is frozen")
+        super().__setattr__(name, value)
 
 
 class ToolContext:


### PR DESCRIPTION
## Summary
- implement helper methods on `Message` and `Step` for enhanced tests
- convert tool call objects and support results in `ToolCallStep`
- make `ToolDefinition` immutable via custom `__setattr__`
- allow `get_config()` to update model/provider from env vars
- ensure finish steps create messages properly

## Testing
- `python -m py_compile src/codin/api/app.py src/codin/actor/dispatcher.py`
- `python -m py_compile src/codin/agent/types.py src/codin/tool/base.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844059de4448320b5a815c7d44f9352