### PR TITLE
Implement lifecycle host types

### DIFF
--- a/src/codin/actor/mailbox.py
+++ b/src/codin/actor/mailbox.py
@@ -6,7 +6,9 @@ import asyncio
 import typing as _t
 from abc import ABC, abstractmethod
 
-from ..agent.types import Message
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ..agent.types import Message
 
 
 __all__ = ["Mailbox", "LocalMailbox", "RayMailbox"]

--- a/src/codin/host/__init__.py
+++ b/src/codin/host/__init__.py
@@ -1,15 +1,7 @@
-"""Host system for codin agents.
+"""Host system for codin agents."""
 
-This module provides host infrastructure for managing agent execution
-environments, including local and distributed hosting capabilities
-for running codin agents at scale.
-"""
+from .base import BaseHost
+from .local import LocalHost
+from .ray import RayHost
 
-import typing as _t
-
-from .agent_host import AgentHost
-from .multi import MultiAgentHost
-from .single import SingleAgentHost
-
-
-__all__ = ['MultiAgentHost', 'SingleAgentHost']
+__all__ = ["BaseHost", "LocalHost", "RayHost"]

--- a/src/codin/host/base.py
+++ b/src/codin/host/base.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from ..config import load_config, CodinConfig
+from ..lifecycle import LifecycleMixin
+
+
+
+logger = logging.getLogger(__name__)
+
+
+class BaseHost(LifecycleMixin):
+    """Base host that manages dispatcher and actor manager."""
+
+    def __init__(self, config_file: str | Path | None = None) -> None:
+        super().__init__()
+        self.config_file = Path(config_file) if config_file else None
+        self.config: Optional[CodinConfig] = None
+        self.dispatcher: Optional['Dispatcher'] = None
+        self.actor_manager: Optional['ActorSupervisor'] = None
+        self._resources: list[LifecycleMixin] = []
+
+    async def _create_actor_manager(self) -> 'ActorSupervisor':
+        """Create the actor manager instance."""
+        return __import__('codin.actor.supervisor', fromlist=['LocalActorManager']).LocalActorManager()
+
+    async def _create_dispatcher(self, manager: 'ActorSupervisor') -> 'Dispatcher':
+        """Create the dispatcher instance."""
+        return __import__('codin.actor.dispatcher', fromlist=['LocalDispatcher']).LocalDispatcher(manager)
+
+    async def _init_components(self) -> None:
+        self.actor_manager = await self._create_actor_manager()
+        self.dispatcher = await self._create_dispatcher(self.actor_manager)
+        for obj in (self.actor_manager, self.dispatcher):
+            if isinstance(obj, LifecycleMixin):
+                self._resources.append(obj)
+
+    async def _up(self) -> None:
+        self.config = load_config(self.config_file)
+        await self._init_components()
+        for res in self._resources:
+            await res.up()
+        logger.info("Host ready")
+
+    async def _down(self) -> None:
+        for res in reversed(self._resources):
+            try:
+                await res.down()
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.error("Error shutting down %s: %s", res, exc)
+        self._resources.clear()
+        self.dispatcher = None
+        self.actor_manager = None
+        logger.info("Host stopped")

--- a/src/codin/host/local.py
+++ b/src/codin/host/local.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from .base import BaseHost
+
+
+logger = logging.getLogger(__name__)
+
+
+class LocalHost(BaseHost):
+    """Local in-process host implementation."""
+
+    def __init__(self, config_file: str | Path | None = None):
+        super().__init__(config_file=config_file)
+
+    async def _create_actor_manager(self) -> 'ActorSupervisor':
+        return __import__('codin.actor.supervisor', fromlist=['LocalActorManager']).LocalActorManager()
+
+    async def _create_dispatcher(self, manager: 'ActorSupervisor') -> 'Dispatcher':
+        return __import__('codin.actor.dispatcher', fromlist=['LocalDispatcher']).LocalDispatcher(manager)

--- a/src/codin/host/ray.py
+++ b/src/codin/host/ray.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from .base import BaseHost
+
+
+try:  # pragma: no cover - optional dependency
+    import ray
+except Exception:  # pragma: no cover - used when ray missing
+    ray = None
+
+logger = logging.getLogger(__name__)
+
+
+class RayHost(BaseHost):
+    """Host that manages agents using Ray."""
+
+    def __init__(self, config_file: str | Path | None = None, *, ray_init_kwargs: dict | None = None):
+        super().__init__(config_file=config_file)
+        self._ray_init_kwargs = ray_init_kwargs or {"local_mode": True, "ignore_reinit_error": True}
+
+    async def _create_actor_manager(self) -> 'ActorSupervisor':
+        if ray is None:
+            raise ImportError("ray is required for RayHost")
+        if not ray.is_initialized():  # pragma: no cover - init if needed
+            ray.init(**self._ray_init_kwargs)
+        return __import__('codin.actor.ray_scheduler', fromlist=['RayActorManager']).RayActorManager()
+
+    async def _create_dispatcher(self, manager: 'ActorSupervisor') -> 'Dispatcher':
+        # Dispatcher implementation is local for now
+        return __import__('codin.actor.dispatcher', fromlist=['LocalDispatcher']).LocalDispatcher(manager)
+
+    async def _down(self) -> None:
+        await super()._down()
+        if ray and ray.is_initialized():  # pragma: no cover
+            ray.shutdown()

--- a/tests/host/test_host_lifecycle.py
+++ b/tests/host/test_host_lifecycle.py
@@ -1,0 +1,27 @@
+import pytest
+
+from codin.host import LocalHost, RayHost
+from codin.lifecycle import LifecycleState
+
+
+@pytest.mark.asyncio
+async def test_local_host_lifecycle():
+    host = LocalHost()
+    assert host.state == LifecycleState.DOWN
+    await host.up()
+    assert host.state == LifecycleState.UP
+    assert host.dispatcher is not None
+    assert host.actor_manager is not None
+    await host.down()
+    assert host.state == LifecycleState.DOWN
+
+
+@pytest.mark.asyncio
+async def test_ray_host_lifecycle():
+    ray = pytest.importorskip("ray")
+    host = RayHost()
+    await host.up()
+    assert host.dispatcher is not None
+    assert host.actor_manager is not None
+    await host.down()
+    assert not ray.is_initialized()


### PR DESCRIPTION
## Summary
- add BaseHost with lifecycle management
- implement LocalHost and RayHost using dynamic imports
- expose new hosts in host package
- adjust mailbox to avoid import cycle
- add tests for host lifecycle

## Testing
- `pytest tests/host/test_host_lifecycle.py -q`
- `pytest -q` *(fails: ImportError in tests/actor/test_dispatcher_reconnect.py)*

------
https://chatgpt.com/codex/tasks/task_e_68441b6f2d8c8320a5de14144f4f5954