### PR TITLE
Use SandboxToolset directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cp .env-example .env
 from codin.agent.base_agent import BaseAgent
 from codin.agent.code_planner import CodePlanner, CodePlannerConfig
 from codin.tool.registry import ToolRegistry
-from codin.tool.core_tools import CoreToolset
+from codin.tool.sandbox import SandboxToolset
 from codin.sandbox.local import LocalSandbox
 
 # Initialize components
@@ -83,9 +83,9 @@ sandbox = LocalSandbox()
 await sandbox.up()
 
 tool_registry = ToolRegistry()
-core_toolset = CoreToolset(sandbox)
-await core_toolset.up()
-tool_registry.register_toolset(core_toolset)
+sandbox_toolset = SandboxToolset(sandbox)
+await sandbox_toolset.up()
+tool_registry.register_toolset(sandbox_toolset)
 
 # Create planner and agent
 planner_config = CodePlannerConfig(model="gpt-4")

--- a/examples/hello_world_test.py
+++ b/examples/hello_world_test.py
@@ -24,7 +24,7 @@ from codin.agent.code_planner import CodePlanner, CodePlannerConfig
 from codin.agent.types import AgentRunInput, RunConfig, ToolCall, Message
 from codin.memory.base import MemMemoryService
 from codin.tool.registry import ToolRegistry
-from codin.tool.core_tools import CoreToolset
+from codin.tool.sandbox import SandboxToolset
 from codin.sandbox.local import LocalSandbox
 from codin.model.base import BaseLLM
 
@@ -35,26 +35,28 @@ logger = logging.getLogger(__name__)
 
 class MockLLM(BaseLLM):
     """Mock LLM for testing that doesn't require API keys."""
-    
+
     def __init__(self):
         super().__init__("mock-llm")
         self.turn_count = 0
-    
+
     @classmethod
     def supported_models(cls) -> list[str]:
         """Return supported model patterns."""
         return ["mock-*"]
-    
-    async def generate(self, 
-                      prompt: str | list[dict[str, str]], 
-                      *, 
-                      stream: bool = False,
-                      temperature: float | None = None,
-                      max_tokens: int | None = None,
-                      stop_sequences: list[str] | None = None) -> str:
+
+    async def generate(
+        self,
+        prompt: str | list[dict[str, str]],
+        *,
+        stream: bool = False,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        stop_sequences: list[str] | None = None,
+    ) -> str:
         """Generate mock responses that simulate the hello world task."""
         self.turn_count += 1
-        
+
         # Mock structured responses for different turns
         if self.turn_count == 1:
             # First turn: Create the hello world script
@@ -115,16 +117,18 @@ class MockLLM(BaseLLM):
     ),
     "should_continue": false
 }```"""
-        
+
         return response_content
-    
-    async def generate_with_tools(self,
-                                prompt: str | list[dict[str, str]],
-                                tools: list[dict],
-                                *,
-                                stream: bool = False,
-                                temperature: float | None = None,
-                                max_tokens: int | None = None) -> dict:
+
+    async def generate_with_tools(
+        self,
+        prompt: str | list[dict[str, str]],
+        tools: list[dict],
+        *,
+        stream: bool = False,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> dict:
         """Generate with tools - delegate to generate for simplicity."""
         content = await self.generate(prompt, stream=stream, temperature=temperature, max_tokens=max_tokens)
         return {"content": content, "tool_calls": []}
@@ -132,25 +136,25 @@ class MockLLM(BaseLLM):
 
 async def create_test_agent():
     """Create BaseAgent with CodePlanner using mock LLM."""
-    
+
     print("🔧 Setting up test environment...")
-    
+
     # 1. Initialize sandbox
     sandbox = LocalSandbox()
     await sandbox.up()
     logger.info("✓ Mock sandbox initialized")
-    
+
     # 2. Setup tool registry
     tool_registry = ToolRegistry()
-    core_toolset = CoreToolset(sandbox)
-    await core_toolset.up()
-    tool_registry.register_toolset(core_toolset)
+    sandbox_toolset = SandboxToolset(sandbox)
+    await sandbox_toolset.up()
+    tool_registry.register_toolset(sandbox_toolset)
     logger.info(f"✓ Registered {len(tool_registry.get_tools())} tools")
-    
+
     # 3. Create mock LLM
     mock_llm = MockLLM()
     logger.info("✓ Mock LLM created")
-    
+
     # 4. Configure planner
     planner_config = CodePlannerConfig(
         model="mock-llm",
@@ -159,28 +163,18 @@ async def create_test_agent():
         max_tool_calls_per_turn=3,
         thinking_enabled=True,
         streaming_enabled=False,
-        rules="Test environment - simulate creating and executing hello world script"
+        rules="Test environment - simulate creating and executing hello world script",
     )
-    planner = CodePlanner(
-        config=planner_config,
-        llm=mock_llm,
-        tool_registry=tool_registry,
-        debug=True
-    )
+    planner = CodePlanner(config=planner_config, llm=mock_llm, tool_registry=tool_registry, debug=True)
     logger.info("✓ CodePlanner created with mock LLM")
-    
+
     # 5. Initialize memory
     memory = MemMemoryService()
     logger.info("✓ Memory service initialized")
-    
+
     # 6. Create agent
-    run_config = RunConfig(
-        turn_budget=10,
-        time_budget_seconds=60,
-        token_budget=5000,
-        cost_budget=0.10
-    )
-    
+    run_config = RunConfig(turn_budget=10, time_budget_seconds=60, token_budget=5000, cost_budget=0.10)
+
     agent = BaseAgent(
         agent_id="test-hello-world-agent",
         name="TestHelloWorldAgent",
@@ -190,21 +184,21 @@ async def create_test_agent():
         tools=tool_registry.get_tools(),
         llm=mock_llm,
         default_config=run_config,
-        debug=True
+        debug=True,
     )
     logger.info("✓ BaseAgent created")
-    
+
     return agent, sandbox
 
 
 async def run_test():
     """Run the test hello world task."""
-    
+
     print("🚀 Starting Hello World Test (Mock LLM)")
     print("=" * 50)
-    
+
     agent, sandbox = await create_test_agent()
-    
+
     try:
         # Create test task message
         task_message = Message(
@@ -212,59 +206,55 @@ async def run_test():
             role=Role.user,
             parts=[TextPart(text="Write a python hello world script and check output result")],
             contextId="test-session",
-            kind="message"
+            kind="message",
         )
-        
+
         # Create agent input
-        agent_input = AgentRunInput(
-            session_id="test-session",
-            message=task_message,
-            options={}
-        )
-        
+        agent_input = AgentRunInput(session_id="test-session", message=task_message, options={})
+
         print(f"📝 Task: {task_message.parts[0].root.text}")
         print()
         print("🤖 Agent executing task with mock LLM...")
         print()
-        
+
         # Track execution
         step_count = 0
         tool_calls_made = 0
-        
+
         # Run the agent
         async for output in agent.run(agent_input):
             step_count += 1
-            
-            if hasattr(output, 'result') and output.result:
+
+            if hasattr(output, "result") and output.result:
                 # Extract and display content
-                if hasattr(output.result, 'parts'):
+                if hasattr(output.result, "parts"):
                     for part in output.result.parts:
                         text = ""
-                        if hasattr(part, 'text'):
+                        if hasattr(part, "text"):
                             text = part.text
-                        elif hasattr(part, 'root') and hasattr(part.root, 'text'):
+                        elif hasattr(part, "root") and hasattr(part.root, "text"):
                             text = part.root.text
-                        
+
                         if text and len(text.strip()) > 0:
                             # Truncate very long outputs for readability
                             if len(text) > 200:
                                 text = text[:200] + "..."
                             print(f"🔹 {text}")
-                
+
                 # Show metadata
-                if hasattr(output, 'metadata') and output.metadata:
-                    step_type = output.metadata.get('step_type', 'unknown')
-                    if step_type == 'tool_call':
+                if hasattr(output, "metadata") and output.metadata:
+                    step_type = output.metadata.get("step_type", "unknown")
+                    if step_type == "tool_call":
                         tool_calls_made += 1
-                        tool_name = output.metadata.get('tool_name', 'unknown')
-                        success = output.metadata.get('success', False)
+                        tool_name = output.metadata.get("tool_name", "unknown")
+                        success = output.metadata.get("success", False)
                         status = "✅" if success else "❌"
                         print(f"  🔧 Tool: {tool_name} {status}")
-                    elif step_type == 'finish':
-                        reason = output.metadata.get('reason', 'completed')
+                    elif step_type == "finish":
+                        reason = output.metadata.get("reason", "completed")
                         print(f"  ✨ Finished: {reason}")
                         break
-        
+
         print()
         print("📊 Execution Summary:")
         print(f"   Steps executed: {step_count}")
@@ -278,11 +268,11 @@ async def run_test():
         print("   2. Agent executes each step")
         print("   3. Tool results feed back to planner")
         print("   4. Loop continues until FinishStep")
-        
+
     except Exception as e:
         logger.error(f"Error during test execution: {e}", exc_info=True)
         print(f"❌ Test failed: {e}")
-        
+
     finally:
         # Cleanup
         try:
@@ -305,4 +295,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(main())

--- a/src/codin/tool/__init__.py
+++ b/src/codin/tool/__init__.py
@@ -7,22 +7,7 @@ execution, registry, and MCP (Model Context Protocol) integration.
 import typing as _t
 
 from .base import Tool, ToolContext, ToolSpec, Toolset  # type: ignore F401 – re-export
-from .core_tools import (
-    # All core tools
-    CodebaseSearchTool,
-    CoreToolset,
-    DeleteFileTool,
-    EditFileTool,
-    FetchTool,
-    FileSearchTool,
-    GrepSearchTool,
-    ListDirTool,
-    ReadFileTool,
-    ReapplyTool,
-    RunShellTool,
-    SearchReplaceTool,
-    WebSearchTool,
-)
+from .core_tools import FetchTool
 from .decorators import ToolDecorator, tool
 from .executor import ToolExecutor
 from .generic import GenericTool, create_tool_from_function
@@ -45,41 +30,29 @@ from .sandbox import (
 
 __all__ = [
     # Core tool system
-    'Tool',
-    'Toolset',
-    'ToolContext',
-    'ToolSpec',
-    'ToolRegistry',
-    'ToolRegistryConfig',
-    'ToolEndpoint',
-    'ToolExecutor',
+    "Tool",
+    "Toolset",
+    "ToolContext",
+    "ToolSpec",
+    "ToolRegistry",
+    "ToolRegistryConfig",
+    "ToolEndpoint",
+    "ToolExecutor",
     # Generic tool support
-    'GenericTool',
-    'create_tool_from_function',
-    'tool',
-    'ToolDecorator',
-    # All core tools
-    'CodebaseSearchTool',
-    'ReadFileTool',
-    'RunShellTool',
-    'ListDirTool',
-    'GrepSearchTool',
-    'EditFileTool',
-    'SearchReplaceTool',
-    'FileSearchTool',
-    'DeleteFileTool',
-    'ReapplyTool',
-    'WebSearchTool',
-    'FetchTool',
-    'CoreToolset',
+    "GenericTool",
+    "create_tool_from_function",
+    "tool",
+    "ToolDecorator",
+    # Core tools
+    "FetchTool",
     # Sandbox tools
-    'SandboxTool',
-    'SandboxToolset',
+    "SandboxTool",
+    "SandboxToolset",
     # MCP tool support
-    'MCPTool',
-    'MCPToolset',
-    'MCPSessionManager',
-    'HttpServerParams',
-    'StdioServerParams',
-    'SseServerParams',
+    "MCPTool",
+    "MCPToolset",
+    "MCPSessionManager",
+    "HttpServerParams",
+    "StdioServerParams",
+    "SseServerParams",
 ]

--- a/src/codin/tool/core_tools.py
+++ b/src/codin/tool/core_tools.py
@@ -1,8 +1,4 @@
-"""Core tools for codin agents.
-
-This module provides essential tools for file operations, code search,
-shell execution, and web interactions that are commonly needed by agents.
-"""
+"""Core tool definitions built on top of sandbox methods."""
 
 from __future__ import annotations
 
@@ -11,669 +7,55 @@ import typing as _t
 
 import pydantic as _pyd
 import requests
-
 from bs4 import BeautifulSoup
 
-from ..sandbox.base import Sandbox
-from .base import Tool, ToolContext, Toolset
-from .sandbox import SandboxTool
+from .base import Tool, ToolContext
 
-
-__all__ = [
-    # Core tools
-    'CodebaseSearchTool',
-    'ReadFileTool',
-    'RunShellTool',
-    'ListDirTool',
-    'GrepSearchTool',
-    'EditFileTool',
-    'SearchReplaceTool',
-    'FileSearchTool',
-    'DeleteFileTool',
-    'ReapplyTool',
-    'WebSearchTool',
-    'FetchTool',
-    # Toolset
-    'CoreToolset',
-]
+__all__ = ["FetchTool"]
 
 logger = logging.getLogger(__name__)
-
-
-# Input schemas for all tools
-class CodebaseSearchInput(_pyd.BaseModel):
-    """Input schema for codebase search."""
-
-    query: str = _pyd.Field(..., description='The search query to find relevant code')
-    explanation: str = _pyd.Field(..., description='One sentence explanation of why this tool is being used')
-    target_directories: list[str] | None = _pyd.Field(
-        None, description='Glob patterns for directories to search over'
-    )
-
-
-class ReadFileInput(_pyd.BaseModel):
-    """Input schema for reading file contents."""
-
-    target_file: str = _pyd.Field(..., description='The path of the file to read')
-    should_read_entire_file: bool = _pyd.Field(..., description='Whether to read the entire file')
-    start_line_one_indexed: int = _pyd.Field(..., description='The one-indexed line number to start reading from')
-    end_line_one_indexed_inclusive: int = _pyd.Field(..., description='The one-indexed line number to end reading at')
-    explanation: str = _pyd.Field(..., description='One sentence explanation of why this tool is being used')
-
-
-class RunShellInput(_pyd.BaseModel):
-    """Input schema for running shell commands."""
-
-    command: str = _pyd.Field(..., description='The terminal command to execute')
-    is_background: bool = _pyd.Field(..., description='Whether the command should be run in the background')
-    explanation: str = _pyd.Field(..., description='One sentence explanation of why this command needs to be run')
-
-
-class ListDirInput(_pyd.BaseModel):
-    """Input schema for listing directory contents."""
-
-    directory: str = _pyd.Field(..., description='Path to list contents of, relative to the workspace root')
-    explanation: str = _pyd.Field(..., description='One sentence explanation of why this tool is being used')
-
-
-class GrepSearchInput(_pyd.BaseModel):
-    """Input schema for grep search."""
-
-    query: str = _pyd.Field(..., description='The regex pattern to search for')
-    explanation: str = _pyd.Field(..., description='One sentence explanation of why this tool is being used')
-    case_sensitive: bool | None = _pyd.Field(None, description='Whether the search should be case sensitive')
-    include_pattern: str | None = _pyd.Field(None, description='Glob pattern for files to include')
-    exclude_pattern: str | None = _pyd.Field(None, description='Glob pattern for files to exclude')
-
-
-class EditFileInput(_pyd.BaseModel):
-    """Input schema for editing files."""
-
-    target_file: str = _pyd.Field(..., description='The target file to modify')
-    instructions: str | None = _pyd.Field(
-        None, description='A single sentence instruction describing what you are going to do'
-    )
-    code_edit: str | None = _pyd.Field(
-        None, description='Specify ONLY the precise lines of code that you wish to edit'
-    )
-    content: str | None = _pyd.Field(
-        None, description='Content to write to the file (for simple write operations)'
-    )
-
-
-class SearchReplaceInput(_pyd.BaseModel):
-    """Input schema for search and replace."""
-
-    file_path: str = _pyd.Field(..., description='The path to the file you want to search and replace in')
-    old_string: str = _pyd.Field(..., description='The text to replace (must be unique within the file)')
-    new_string: str = _pyd.Field(..., description='The edited text to replace the old_string')
-
-
-class FileSearchInput(_pyd.BaseModel):
-    """Input schema for file search."""
-
-    query: str = _pyd.Field(..., description='Fuzzy filename to search for')
-    explanation: str = _pyd.Field(..., description='One sentence explanation of why this tool is being used')
-
-
-class DeleteFileInput(_pyd.BaseModel):
-    """Input schema for deleting files."""
-
-    target_file: str = _pyd.Field(..., description='The path of the file to delete, relative to the workspace root')
-    explanation: str = _pyd.Field(..., description='One sentence explanation of why this tool is being used')
-
-
-class ReapplyInput(_pyd.BaseModel):
-    """Input schema for reapplying edits."""
-
-    target_file: str = _pyd.Field(..., description='The relative path to the file to reapply the last edit to')
-
-
-class WebSearchInput(_pyd.BaseModel):
-    """Input schema for web search."""
-
-    search_term: str = _pyd.Field(..., description='The search term to look up on the web')
-    explanation: str = _pyd.Field(..., description='One sentence explanation of why this tool is being used')
 
 
 class FetchInput(_pyd.BaseModel):
     """Input schema for fetching URLs."""
 
-    url: str = _pyd.Field(..., description='URL to fetch')
-    max_length: int | None = _pyd.Field(5000, description='Maximum number of characters to return')
-    raw: bool | None = _pyd.Field(False, description='Get the actual HTML content without simplification')
-    start_index: int | None = _pyd.Field(0, description='Starting character index for output')
-
-
-# Tool implementations
-class CodebaseSearchTool(SandboxTool):
-    """Tool for semantic search over the codebase."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='codebase_search',
-            description=(
-                'Find snippets of code from the codebase most relevant to the search query. '
-                'This is a semantic search tool, so the query should ask for something '
-                'semantically matching what is needed.'
-            ),
-            sandbox=sandbox,
-            input_schema=CodebaseSearchInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Perform semantic search over the codebase."""
-        query = args['query']
-        target_directories = args.get('target_directories', [])
-
-        # For now, implement as a simple grep-based search
-        # In a real implementation, this would use semantic search
-        try:
-            cmd = ['rg', '-n', '--type', 'py', '--type', 'js', '--type', 'ts', query]
-            if target_directories:
-                for dir_pattern in target_directories:
-                    cmd.extend(['-g', dir_pattern])
-
-            result = await self.sandbox.run_cmd(cmd)
-
-            if result.exit_code == 0:
-                lines = result.stdout.strip().split('\n') if result.stdout.strip() else []
-                results = []
-                for line in lines[:20]:  # Limit results
-                    if ':' in line:
-                        parts = line.split(':', 2)
-                        if len(parts) >= 3:
-                            results.append(
-                                {
-                                    'file': parts[0],
-                                    'line': parts[1],
-                                    'content': parts[2].strip(),
-                                    'relevance': 0.8,  # Mock relevance score
-                                }
-                            )
-
-                return {'query': query, 'target_directories': target_directories, 'results': results}
-            return {'query': query, 'target_directories': target_directories, 'results': [], 'error': result.stderr}
-        except Exception as e:
-            logger.error(f'Error in codebase search: {e}')
-            return {'query': query, 'target_directories': target_directories, 'results': [], 'error': str(e)}
-
-
-class ReadFileTool(SandboxTool):
-    """Tool for reading file contents with line range support."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='read_file',
-            description=(
-                'Read the contents of a file. the output of this tool call will be the '
-                '1-indexed file contents from start_line_one_indexed to end_line_one_indexed_inclusive, '
-                'together with a summary of the lines outside start_line_one_indexed and '
-                'end_line_one_indexed_inclusive. Note that this call can view at most 250 lines '
-                'at a time and 200 lines minimum.'
-            ),
-            sandbox=sandbox,
-            input_schema=ReadFileInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> str:
-        """Read file contents from the sandbox."""
-        target_file = args['target_file']
-        should_read_entire_file = args['should_read_entire_file']
-        start_line = args['start_line_one_indexed']
-        end_line = args['end_line_one_indexed_inclusive']
-
-        try:
-            content = await self.sandbox.read_file(target_file)
-            lines = content.splitlines()
-            total_lines = len(lines)
-
-            if should_read_entire_file:
-                return content
-
-            # Validate line numbers
-            start_line = max(1, start_line)
-            end_line = min(total_lines, end_line)
-            start_line = min(start_line, end_line)
-
-            # Limit to 250 lines max, 200 lines min
-            requested_lines = end_line - start_line + 1
-            if requested_lines > 250:
-                end_line = start_line + 249
-            elif requested_lines < 200 and total_lines >= 200:
-                needed = 200 - requested_lines
-                expand_start = min(needed // 2, start_line - 1)
-                expand_end = min(needed - expand_start, total_lines - end_line)
-                start_line = max(1, start_line - expand_start)
-                end_line = min(total_lines, end_line + expand_end)
-
-            # Extract requested lines
-            start_idx = start_line - 1
-            end_idx = end_line
-            selected_lines = lines[start_idx:end_idx]
-
-            # Create result with metadata
-            result_parts = []
-            if start_line > 1:
-                result_parts.append(f'Lines 1-{start_line - 1} not shown ({start_line - 1} lines)')
-
-            result_parts.append(
-                f'Contents of {target_file}, lines {start_line}-{min(end_line, total_lines)} '
-                f'(total {total_lines} lines):'
-            )
-            result_parts.append('\n'.join(selected_lines))
-
-            if end_line < total_lines:
-                result_parts.append(f'Lines {end_line + 1}-{total_lines} not shown ({total_lines - end_line} lines)')
-
-            return '\n'.join(result_parts)
-
-        except Exception as e:
-            logger.error(f'Error reading file {target_file}: {e}')
-            return f'Error reading file {target_file}: {e!s}'
-
-
-class RunShellTool(SandboxTool):
-    """Unified tool for running shell commands (combines shell, sandbox_exec, container_exec, run_terminal_cmd)."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='run_shell',
-            description=(
-                'PROPOSE a command to run on behalf of the user. If you have this tool, '
-                "note that you DO have the ability to run commands directly on the USER's system. "
-                'Note that the user will have to approve the command before it is executed. '
-                'The user may reject it if it is not to their liking, or may modify the command '
-                'before approving it. If they do change it, take those changes into account. '
-                'The actual command will NOT execute until the user approves it. The user may not '
-                'approve it immediately. Do NOT assume the command has started running. '
-                'If the step is WAITING for user approval, it has NOT started running.'
-            ),
-            sandbox=sandbox,
-            input_schema=RunShellInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Execute a shell command in the sandbox."""
-        command = args['command']
-        is_background = args['is_background']
-
-        try:
-            if is_background:
-                # For background commands, start them and return immediately
-                result = await self.sandbox.run_cmd(['nohup', 'sh', '-c', f'{command} &'], timeout=5.0)
-                return {
-                    'command': command,
-                    'background': True,
-                    'started': result.exit_code == 0,
-                    'stdout': result.stdout,
-                    'stderr': result.stderr,
-                    'exit_code': result.exit_code,
-                }
-            # Regular command execution
-            result = await self.sandbox.run_cmd(['sh', '-c', command])
-            return {
-                'command': command,
-                'background': False,
-                'stdout': result.stdout,
-                'stderr': result.stderr,
-                'exit_code': result.exit_code,
-            }
-
-        except Exception as e:
-            logger.error(f"Error executing command '{command}': {e}")
-            return {'command': command, 'background': is_background, 'error': str(e), 'exit_code': -1}
-
-
-class ListDirTool(SandboxTool):
-    """Tool for listing directory contents."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='list_dir',
-            description=(
-                'List the contents of a directory. The quick tool to use for discovery, '
-                'before using more targeted tools like semantic search or file reading. '
-                'Useful to try to understand the file structure before diving deeper into '
-                'specific files. Can be used to explore the codebase.'
-            ),
-            sandbox=sandbox,
-            input_schema=ListDirInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """List directory contents in the sandbox."""
-        path = args['relative_workspace_path']
-
-        try:
-            if hasattr(self.sandbox, 'list_files'):
-                files = await self.sandbox.list_files(path)
-                return {'path': path, 'contents': files}
-            result = await self.sandbox.run_cmd(['ls', '-la', path])
-            if result.exit_code != 0:
-                return {'path': path, 'error': result.stderr, 'exit_code': result.exit_code}
-
-            return {'path': path, 'contents': result.stdout.strip().split('\n') if result.stdout.strip() else []}
-        except Exception as e:
-            logger.error(f'Error listing directory {path}: {e}')
-            return {'path': path, 'error': str(e)}
-
-
-class GrepSearchTool(SandboxTool):
-    """Tool for regex search using ripgrep."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='grep_search',
-            description=(
-                'Use this tool to run fast, exact regex searches over text files using the '
-                'ripgrep engine. This is preferred over semantic search when we know the exact '
-                'symbol/function name/etc. to search in some set of directories/file types.'
-            ),
-            sandbox=sandbox,
-            input_schema=GrepSearchInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Perform regex search using ripgrep."""
-        query = args['query']
-        case_sensitive = args.get('case_sensitive', False)
-        include_pattern = args.get('include_pattern')
-        exclude_pattern = args.get('exclude_pattern')
-
-        try:
-            cmd = ['rg', query]
-
-            if not case_sensitive:
-                cmd.append('-i')
-
-            if include_pattern:
-                cmd.extend(['-g', include_pattern])
-
-            if exclude_pattern:
-                cmd.extend(['-g', f'!{exclude_pattern}'])
-
-            # Limit results to prevent overwhelming output
-            cmd.extend(['-m', '50'])
-
-            result = await self.sandbox.run_cmd(cmd)
-
-            if result.exit_code == 0:
-                results = result.stdout.strip().split('\n') if result.stdout.strip() else []
-                return {'query': query, 'results': results, 'count': len(results)}
-            return {'query': query, 'error': result.stderr, 'results': []}
-
-        except Exception as e:
-            logger.error(f'Error in grep search: {e}')
-            return {'query': query, 'error': str(e), 'results': []}
-
-
-class EditFileTool(SandboxTool):
-    """Tool for editing and writing files (merged functionality from SandboxWriteFileTool)."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='edit_file',
-            description=(
-                'Use this tool to propose an edit to an existing file or create a new file. '
-                'This will be read by a less intelligent model, which will quickly apply the edit. '
-                'You should make it clear what the edit is, while also minimizing the unchanged '
-                'code you write. Can also be used for simple file writing operations.'
-            ),
-            sandbox=sandbox,
-            input_schema=EditFileInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Edit or create a file."""
-        target_file = args['target_file']
-        code_edit = args.get('code_edit')
-        content = args.get('content')
-
-        try:
-            # Determine what content to write
-            if content is not None:
-                # Simple write operation (like SandboxWriteFileTool)
-                write_content = content
-            elif code_edit is not None:
-                # Complex edit operation
-                write_content = code_edit
-            else:
-                return {
-                    'target_file': target_file,
-                    'success': False,
-                    'error': "Either 'content' or 'code_edit' must be provided",
-                }
-
-            await self.sandbox.write_file(target_file, write_content)
-
-            return {
-                'target_file': target_file,
-                'success': True,
-                'message': f'File {target_file} {"written" if content else "edited"} successfully',
-            }
-
-        except Exception as e:
-            logger.error(f'Error editing file {target_file}: {e}')
-            return {'target_file': target_file, 'success': False, 'error': str(e)}
-
-
-class SearchReplaceTool(SandboxTool):
-    """Tool for search and replace operations."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='search_replace',
-            description=(
-                'Use this tool to propose a search and replace operation on an existing file. '
-                'The tool will replace ONE occurrence of old_string with new_string in the '
-                'specified file.'
-            ),
-            sandbox=sandbox,
-            input_schema=SearchReplaceInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Perform search and replace in a file."""
-        file_path = args['file_path']
-        old_string = args['old_string']
-        new_string = args['new_string']
-
-        try:
-            content = await self.sandbox.read_file(file_path)
-
-            if old_string not in content:
-                return {'file_path': file_path, 'success': False, 'error': 'Old string not found in file'}
-
-            # Replace only the first occurrence
-            new_content = content.replace(old_string, new_string, 1)
-            await self.sandbox.write_file(file_path, new_content)
-
-            return {'file_path': file_path, 'success': True, 'message': 'Search and replace completed successfully'}
-
-        except Exception as e:
-            logger.error(f'Error in search and replace for {file_path}: {e}')
-            return {'file_path': file_path, 'success': False, 'error': str(e)}
-
-
-class FileSearchTool(SandboxTool):
-    """Tool for fuzzy file search."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='file_search',
-            description=(
-                'Fast file search based on fuzzy matching against file path. Use if you know '
-                "part of the file path but don't know where it's located exactly. Response will "
-                'be capped to 10 results.'
-            ),
-            sandbox=sandbox,
-            input_schema=FileSearchInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Search for files by fuzzy matching."""
-        query = args['query']
-
-        try:
-            # Use find command for basic file search
-            cmd = ['find', '.', '-name', f'*{query}*', '-type', 'f']
-
-            result = await self.sandbox.run_cmd(cmd)
-
-            if result.exit_code == 0:
-                files = result.stdout.strip().split('\n') if result.stdout.strip() else []
-                files = [f for f in files if f]  # Remove empty strings
-                files = files[:10]  # Limit to 10 results
-
-                return {'query': query, 'files': files, 'count': len(files)}
-            return {'query': query, 'error': result.stderr, 'files': []}
-
-        except Exception as e:
-            logger.error(f'Error in file search: {e}')
-            return {'query': query, 'error': str(e), 'files': []}
-
-
-class DeleteFileTool(SandboxTool):
-    """Tool for deleting files."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='delete_file',
-            description=(
-                'Deletes a file at the specified path. The operation will fail gracefully if '
-                "the file doesn't exist, the operation is rejected for security reasons, or the "
-                'file cannot be deleted.'
-            ),
-            sandbox=sandbox,
-            input_schema=DeleteFileInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Delete a file."""
-        target_file = args['target_file']
-
-        try:
-            # Use rm command to delete the file
-            result = await self.sandbox.run_cmd(['rm', '-f', target_file])
-
-            if result.exit_code == 0:
-                return {
-                    'target_file': target_file,
-                    'success': True,
-                    'message': f'File {target_file} deleted successfully',
-                }
-            return {'target_file': target_file, 'success': False, 'error': result.stderr or 'Failed to delete file'}
-
-        except Exception as e:
-            logger.error(f'Error deleting file {target_file}: {e}')
-            return {'target_file': target_file, 'success': False, 'error': str(e)}
-
-
-class ReapplyTool(SandboxTool):
-    """Tool for reapplying the last edit."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='reapply',
-            description=(
-                'Calls a smarter model to apply the last edit to the specified file. Use this tool '
-                'immediately after the result of an edit_file tool call ONLY IF the diff is not '
-                'what you expected, indicating the model applying the changes was not smart enough '
-                'to follow your instructions.'
-            ),
-            sandbox=sandbox,
-            input_schema=ReapplyInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Reapply the last edit to a file."""
-        target_file = args['target_file']
-
-        # This is a placeholder implementation
-        # In a real system, this would track the last edit and reapply it
-        return {
-            'target_file': target_file,
-            'success': False,
-            'message': 'Reapply functionality not yet implemented - no previous edit to reapply',
-        }
-
-
-class WebSearchTool(SandboxTool):
-    """Tool for web search."""
-
-    def __init__(self, sandbox: Sandbox):
-        super().__init__(
-            name='web_search',
-            description=(
-                'Search the web for real-time information about any topic. Use this tool when you '
-                'need up-to-date information that might not be available in your training data, or '
-                'when you need to verify current facts.'
-            ),
-            sandbox=sandbox,
-            input_schema=WebSearchInput,
-        )
-
-    async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Search the web for information."""
-        search_term = args['search_term']
-
-        # This is a placeholder implementation
-        # In a real system, this would integrate with a web search API
-        return {
-            'search_term': search_term,
-            'results': [
-                {
-                    'title': f'Search result for: {search_term}',
-                    'url': 'https://example.com',
-                    'snippet': (
-                        'This is a placeholder search result. In a real implementation, '
-                        'this would connect to a search API.'
-                    ),
-                }
-            ],
-        }
+    url: str = _pyd.Field(..., description="URL to fetch")
+    max_length: int | None = _pyd.Field(5000, description="Maximum number of characters to return")
+    raw: bool | None = _pyd.Field(False, description="Get the actual HTML content without simplification")
+    start_index: int | None = _pyd.Field(0, description="Starting character index for output")
 
 
 class FetchTool(Tool):
-    """Tool for fetching URLs using requests (merged with load_web_page functionality)."""
+    """Tool for fetching URLs using requests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
-            name='fetch',
+            name="fetch",
             description=(
-                'Fetches a URL from the internet and optionally extracts its contents as markdown. '
-                'Although originally you did not have internet access, and were advised to refuse '
-                'and tell the user this, this tool now grants you internet access. Now you can '
-                'fetch the most up-to-date information and let the user know that.'
+                "Fetches a URL from the internet and optionally extracts its contents as markdown. "
+                "Although originally you did not have internet access, and were advised to refuse and tell the user this, "
+                "this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that."
             ),
             input_schema=FetchInput,
         )
 
     async def run(self, args: dict[str, _t.Any], tool_context: ToolContext) -> dict[str, _t.Any]:
-        """Fetch content from a URL using requests."""
-        url = args['url']
-        max_length = args.get('max_length', 5000)
-        raw = args.get('raw', False)
-        start_index = args.get('start_index', 0)
+        url = args["url"]
+        max_length = args.get("max_length", 5000)
+        raw = args.get("raw", False)
+        start_index = args.get("start_index", 0)
 
         try:
-            # Use requests to fetch the URL
             response = requests.get(url, timeout=30)
             response.raise_for_status()
 
             if raw:
-                # Return raw HTML content
                 content = response.text
             else:
-                # Extract text content using BeautifulSoup (like load_web_page)
-                soup = BeautifulSoup(response.content, 'html.parser')
-                text = soup.get_text(separator='\n', strip=True)
+                soup = BeautifulSoup(response.content, "html.parser")
+                text = soup.get_text(separator="\n", strip=True)
+                content = "\n".join(line for line in text.splitlines() if len(line.split()) > 3)
 
-                # Filter out very short lines (like load_web_page)
-                content = '\n'.join(line for line in text.splitlines() if len(line.split()) > 3)
-
-            # Apply start_index and max_length
             if start_index > 0:
                 content = content[start_index:]
 
@@ -682,63 +64,16 @@ class FetchTool(Tool):
                 content = content[:max_length]
 
             return {
-                'url': url,
-                'content': content,
-                'length': len(content),
-                'original_length': original_length,
-                'truncated': original_length > max_length,
-                'status_code': response.status_code,
+                "url": url,
+                "content": content,
+                "length": len(content),
+                "original_length": original_length,
+                "truncated": original_length > max_length,
+                "status_code": response.status_code,
             }
-
         except requests.RequestException as e:
-            logger.error(f'Error fetching URL {url}: {e}')
-            return {'url': url, 'error': f'Request failed: {e!s}', 'content': ''}
-        except Exception as e:
-            logger.error(f'Error processing URL {url}: {e}')
-            return {'url': url, 'error': str(e), 'content': ''}
-
-
-class CoreToolset(Toolset):
-    """Toolset containing all core tools for code agents."""
-
-    def __init__(self, sandbox: Sandbox):
-        """Initialize the core toolset with a sandbox."""
-        tools = [
-            CodebaseSearchTool(sandbox),
-            ReadFileTool(sandbox),
-            RunShellTool(sandbox),
-            ListDirTool(sandbox),
-            GrepSearchTool(sandbox),
-            EditFileTool(sandbox),  # Now includes SandboxWriteFileTool functionality
-            SearchReplaceTool(sandbox),
-            FileSearchTool(sandbox),
-            DeleteFileTool(sandbox),
-            ReapplyTool(sandbox),
-            WebSearchTool(sandbox),
-            FetchTool(),  # FetchTool doesn't need sandbox
-        ]
-
-        super().__init__(
-            name='core',
-            description='Core tools for file system operations, shell execution, and code analysis',
-            tools=tools,
-        )
-        self.sandbox = sandbox
-
-    async def _up(self) -> None:
-        """Bring up the core toolset."""
-        # Start the sandbox first
-        if self.sandbox.is_down:
-            await self.sandbox.up()
-
-        # Bring up all tools
-        await super()._up()
-
-    async def _down(self) -> None:
-        """Bring down the core toolset."""
-        # Bring down all tools first
-        await super()._down()
-
-        # Then stop the sandbox if it's running
-        if self.sandbox.is_up:
-            await self.sandbox.down()
+            logger.error(f"Error fetching URL {url}: {e}")
+            return {"url": url, "error": f"Request failed: {e!s}", "content": ""}
+        except Exception as e:  # pragma: no cover - safeguard
+            logger.error(f"Error processing URL {url}: {e}")
+            return {"url": url, "error": str(e), "content": ""}

--- a/tests/tool/test_core_tools.py
+++ b/tests/tool/test_core_tools.py
@@ -6,11 +6,8 @@ import pathlib
 import os
 from unittest.mock import AsyncMock, MagicMock
 
-from codin.tool.core_tools import (
-    CodebaseSearchTool, ReadFileTool, RunShellTool, ListDirTool, 
-    GrepSearchTool, EditFileTool, SearchReplaceTool, FileSearchTool,
-    DeleteFileTool, ReapplyTool, WebSearchTool, FetchTool, CoreToolset
-)
+from codin.tool.core_tools import FetchTool
+from codin.tool.sandbox import SandboxToolset
 from codin.tool.base import ToolContext
 from codin.sandbox.local import LocalSandbox
 
@@ -26,98 +23,92 @@ async def sandbox():
 
 @pytest.fixture
 def tool_context():
-    return ToolContext(
-        tool_name="test_tool",
-        arguments={},
-        session_id="test_session"
-    )
+    return ToolContext(tool_name="test_tool", arguments={}, session_id="test_session")
+
+
+@pytest.fixture
+def sandbox_toolset(sandbox):
+    """Create SandboxToolset for tests."""
+    return SandboxToolset(sandbox)
 
 
 @pytest.mark.asyncio
-async def test_codebase_search_tool(sandbox, tool_context):
+async def test_codebase_search_tool(sandbox_toolset, sandbox, tool_context):
     """Test CodebaseSearchTool functionality."""
     # Create a test file with searchable content
     await sandbox.write_file("test_search.py", "def test_function():\n    return 'test'")
-    
-    tool = CodebaseSearchTool(sandbox)
-    
-    args = {
-        "query": "test_function",
-        "explanation": "Testing codebase search",
-        "target_directories": None
-    }
-    
+
+    tool = sandbox_toolset.get_tool("codebase_search")
+
+    args = {"query": "test_function", "explanation": "Testing codebase search", "target_directories": None}
+
     result = await tool.run(args, tool_context)
-    
+
     assert "query" in result
     assert "results" in result
     assert result["query"] == "test_function"
 
 
 @pytest.mark.asyncio
-async def test_read_file_tool(sandbox, tool_context):
+async def test_read_file_tool(sandbox_toolset, sandbox, tool_context):
     """Test ReadFileTool functionality."""
     # Create a test file
     test_content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"
     await sandbox.write_file("test.txt", test_content)
-    
-    tool = ReadFileTool(sandbox)
-    
+
+    tool = sandbox_toolset.get_tool("read_file")
+
     # Test reading entire file
     args = {
         "target_file": "test.txt",
         "should_read_entire_file": True,
         "start_line_one_indexed": 1,
         "end_line_one_indexed_inclusive": 5,
-        "explanation": "Testing file reading"
+        "explanation": "Testing file reading",
     }
-    
+
     result = await tool.run(args, tool_context)
-    
+
     assert isinstance(result, str)
     assert "Line 1" in result
     assert "Line 5" in result
 
 
 @pytest.mark.asyncio
-async def test_read_file_tool_line_range(sandbox, tool_context):
+async def test_read_file_tool_line_range(sandbox_toolset, sandbox, tool_context):
     """Test ReadFileTool with line range."""
     # Create a test file
     test_content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"
     await sandbox.write_file("test.txt", test_content)
-    
-    tool = ReadFileTool(sandbox)
-    
+
+    tool = sandbox_toolset.get_tool("read_file")
+
     # Test reading specific line range
     args = {
         "target_file": "test.txt",
         "should_read_entire_file": False,
         "start_line_one_indexed": 2,
         "end_line_one_indexed_inclusive": 4,
-        "explanation": "Testing line range reading"
+        "explanation": "Testing line range reading",
     }
-    
+
     result = await tool.run(args, tool_context)
-    
+
     assert isinstance(result, str)
     assert "Line 2" in result
     assert "Line 4" in result
 
 
 @pytest.mark.asyncio
-async def test_run_shell_tool(sandbox, tool_context):
+async def test_run_shell_tool(sandbox_toolset, sandbox, tool_context):
     """Test RunShellTool functionality."""
-    tool = RunShellTool(sandbox)
-    
+    tool = sandbox_toolset.get_tool("run_shell")
+
     # Test regular command execution
-    args = {
-        "command": "echo Hello World",
-        "is_background": False,
-        "explanation": "Testing command execution"
-    }
-    
+    args = {"command": "echo Hello World", "is_background": False, "explanation": "Testing command execution"}
+
     result = await tool.run(args, tool_context)
-    
+
     assert isinstance(result, dict)
     assert "command" in result
     assert "stdout" in result
@@ -127,19 +118,15 @@ async def test_run_shell_tool(sandbox, tool_context):
 
 
 @pytest.mark.asyncio
-async def test_run_shell_tool_background(sandbox, tool_context):
+async def test_run_shell_tool_background(sandbox_toolset, sandbox, tool_context):
     """Test RunShellTool background execution."""
-    tool = RunShellTool(sandbox)
-    
+    tool = sandbox_toolset.get_tool("run_shell")
+
     # Test background command execution (use a simple command that works on all platforms)
-    args = {
-        "command": "echo Background Test",
-        "is_background": True,
-        "explanation": "Testing background execution"
-    }
-    
+    args = {"command": "echo Background Test", "is_background": True, "explanation": "Testing background execution"}
+
     result = await tool.run(args, tool_context)
-    
+
     assert isinstance(result, dict)
     assert "command" in result
     assert "background" in result
@@ -147,21 +134,18 @@ async def test_run_shell_tool_background(sandbox, tool_context):
 
 
 @pytest.mark.asyncio
-async def test_list_dir_tool(sandbox, tool_context):
+async def test_list_dir_tool(sandbox_toolset, sandbox, tool_context):
     """Test ListDirTool functionality."""
     # Create some test files
     await sandbox.write_file("test1.txt", "content1")
     await sandbox.write_file("test2.py", "content2")
-    
-    tool = ListDirTool(sandbox)
-    
-    args = {
-        "relative_workspace_path": ".",
-        "explanation": "Testing directory listing"
-    }
-    
+
+    tool = sandbox_toolset.get_tool("list_dir")
+
+    args = {"relative_workspace_path": ".", "explanation": "Testing directory listing"}
+
     result = await tool.run(args, tool_context)
-    
+
     assert "path" in result
     assert "contents" in result
     assert result["path"] == "."
@@ -169,22 +153,22 @@ async def test_list_dir_tool(sandbox, tool_context):
 
 
 @pytest.mark.asyncio
-async def test_grep_search_tool(sandbox, tool_context):
+async def test_grep_search_tool(sandbox_toolset, sandbox, tool_context):
     """Test GrepSearchTool functionality."""
     # Create a test file with searchable content
     await sandbox.write_file("test_grep.py", "def test_function():\n    return 'test'")
-    
-    tool = GrepSearchTool(sandbox)
-    
+
+    tool = sandbox_toolset.get_tool("grep_search")
+
     args = {
         "query": "test_function",
         "explanation": "Testing grep search",
         "case_sensitive": False,
-        "include_pattern": "*.py"
+        "include_pattern": "*.py",
     }
-    
+
     result = await tool.run(args, tool_context)
-    
+
     assert "query" in result
     assert "results" in result
     # The tool should always return these fields, even if there's an error
@@ -192,22 +176,22 @@ async def test_grep_search_tool(sandbox, tool_context):
 
 
 @pytest.mark.asyncio
-async def test_edit_file_tool(sandbox, tool_context):
+async def test_edit_file_tool(sandbox_toolset, sandbox, tool_context):
     """Test EditFileTool functionality."""
-    tool = EditFileTool(sandbox)
-    
+    tool = sandbox_toolset.get_tool("edit_file")
+
     args = {
         "target_file": "test_edit.py",
         "instructions": "Create a test file",
-        "code_edit": "def test():\n    return 'hello'"
+        "code_edit": "def test():\n    return 'hello'",
     }
-    
+
     result = await tool.run(args, tool_context)
-    
+
     assert "target_file" in result
     assert "success" in result
     assert result["success"] is True
-    
+
     # Verify file was created
     content = await sandbox.read_file("test_edit.py")
     assert "def test():" in content
@@ -218,20 +202,16 @@ async def test_search_replace_tool(sandbox, tool_context):
     """Test SearchReplaceTool functionality."""
     # Create a test file
     await sandbox.write_file("test_replace.txt", "Line 1\nLine 2\nLine 3")
-    
-    tool = SearchReplaceTool(sandbox)
-    
-    args = {
-        "file_path": "test_replace.txt",
-        "old_string": "Line 1",
-        "new_string": "Modified Line 1"
-    }
-    
+
+    tool = sandbox_toolset.get_tool("search_replace")
+
+    args = {"file_path": "test_replace.txt", "old_string": "Line 1", "new_string": "Modified Line 1"}
+
     result = await tool.run(args, tool_context)
-    
+
     assert "file_path" in result
     assert "success" in result
-    
+
     # Verify replacement worked
     if result["success"]:
         content = await sandbox.read_file("test_replace.txt")
@@ -239,21 +219,18 @@ async def test_search_replace_tool(sandbox, tool_context):
 
 
 @pytest.mark.asyncio
-async def test_file_search_tool(sandbox, tool_context):
+async def test_file_search_tool(sandbox_toolset, sandbox, tool_context):
     """Test FileSearchTool functionality."""
     # Create some test files
     await sandbox.write_file("test_search_file.py", "content")
     await sandbox.write_file("another_test.txt", "content")
-    
-    tool = FileSearchTool(sandbox)
-    
-    args = {
-        "query": "test",
-        "explanation": "Testing file search"
-    }
-    
+
+    tool = sandbox_toolset.get_tool("file_search")
+
+    args = {"query": "test", "explanation": "Testing file search"}
+
     result = await tool.run(args, tool_context)
-    
+
     assert "query" in result
     assert "files" in result
     # The tool should always return these fields, even if there's an error
@@ -261,35 +238,30 @@ async def test_file_search_tool(sandbox, tool_context):
 
 
 @pytest.mark.asyncio
-async def test_delete_file_tool(sandbox, tool_context):
+async def test_delete_file_tool(sandbox_toolset, sandbox, tool_context):
     """Test DeleteFileTool functionality."""
     # Create a test file to delete
     await sandbox.write_file("test_delete.txt", "content to delete")
-    
-    tool = DeleteFileTool(sandbox)
-    
-    args = {
-        "target_file": "test_delete.txt",
-        "explanation": "Testing file deletion"
-    }
-    
+
+    tool = sandbox_toolset.get_tool("delete_file")
+
+    args = {"target_file": "test_delete.txt", "explanation": "Testing file deletion"}
+
     result = await tool.run(args, tool_context)
-    
+
     assert "target_file" in result
     assert "success" in result
 
 
 @pytest.mark.asyncio
-async def test_reapply_tool(sandbox, tool_context):
+async def test_reapply_tool(sandbox_toolset, sandbox, tool_context):
     """Test ReapplyTool functionality."""
-    tool = ReapplyTool(sandbox)
-    
-    args = {
-        "target_file": "test.txt"
-    }
-    
+    tool = sandbox_toolset.get_tool("reapply")
+
+    args = {"target_file": "test.txt"}
+
     result = await tool.run(args, tool_context)
-    
+
     assert "target_file" in result
     assert "success" in result
     # Should be False since it's not implemented
@@ -297,17 +269,14 @@ async def test_reapply_tool(sandbox, tool_context):
 
 
 @pytest.mark.asyncio
-async def test_web_search_tool(sandbox, tool_context):
+async def test_web_search_tool(sandbox_toolset, sandbox, tool_context):
     """Test WebSearchTool functionality."""
-    tool = WebSearchTool(sandbox)
-    
-    args = {
-        "search_term": "python programming",
-        "explanation": "Testing web search"
-    }
-    
+    tool = sandbox_toolset.get_tool("web_search")
+
+    args = {"search_term": "python programming", "explanation": "Testing web search"}
+
     result = await tool.run(args, tool_context)
-    
+
     assert "search_term" in result
     assert "results" in result
 
@@ -316,16 +285,16 @@ async def test_web_search_tool(sandbox, tool_context):
 async def test_fetch_tool(tool_context):
     """Test FetchTool functionality."""
     tool = FetchTool()  # No longer takes sandbox parameter
-    
+
     args = {
         "url": "https://httpbin.org/html",  # Use a reliable test URL
         "max_length": 1000,
         "raw": False,
-        "start_index": 0
+        "start_index": 0,
     }
-    
+
     result = await tool.run(args, tool_context)
-    
+
     assert "url" in result
     assert "content" in result
     # Should have status_code for successful requests
@@ -334,26 +303,35 @@ async def test_fetch_tool(tool_context):
 
 
 @pytest.mark.asyncio
-async def test_core_toolset(sandbox):
-    """Test CoreToolset initialization and functionality."""
-    toolset = CoreToolset(sandbox)
-    
+async def test_sandbox_toolset(sandbox):
+    """Test SandboxToolset initialization and functionality."""
+    toolset = SandboxToolset(sandbox)
+
     # Check that all expected tools are present
-    assert len(toolset.tools) == 12  # All 12 core tools
-    
+    assert len(toolset.tools) == 12  # All 12 sandbox tools
+
     tool_names = [tool.name for tool in toolset.tools]
     expected_tools = [
-        "codebase_search", "read_file", "run_shell", "list_dir",
-        "grep_search", "edit_file", "search_replace", "file_search",
-        "delete_file", "reapply", "web_search", "fetch"
+        "codebase_search",
+        "read_file",
+        "run_shell",
+        "list_dir",
+        "grep_search",
+        "edit_file",
+        "search_replace",
+        "file_search",
+        "delete_file",
+        "reapply",
+        "web_search",
+        "fetch",
     ]
-    
+
     for expected_tool in expected_tools:
         assert expected_tool in tool_names
-    
+
     # Test toolset lifecycle
     await toolset.up()
-    
+
     # Test getting tools
     read_file_tool = toolset.get_tool("read_file")
     assert read_file_tool is not None
@@ -361,20 +339,21 @@ async def test_core_toolset(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_tool_lifecycle(sandbox, tool_context):
+async def test_tool_lifecycle(sandbox_toolset, sandbox, tool_context):
     """Test tool lifecycle."""
-    tool = ListDirTool(sandbox)
-    
+    tool = sandbox_toolset.get_tool("list_dir")
+
     # Initially down
     from codin.lifecycle import LifecycleState
+
     assert tool.state == LifecycleState.DOWN
     assert not tool.is_up
-    
+
     # Bring up
     await tool.up()
     assert tool.state == LifecycleState.UP
     assert tool.is_up
-    
+
     # Bring down
     await tool.down()
     assert tool.state == LifecycleState.DOWN
@@ -382,20 +361,20 @@ async def test_tool_lifecycle(sandbox, tool_context):
 
 
 @pytest.mark.asyncio
-async def test_tool_error_handling(sandbox, tool_context):
+async def test_tool_error_handling(sandbox_toolset, sandbox, tool_context):
     """Test tool error handling."""
-    tool = ReadFileTool(sandbox)
-    
+    tool = sandbox_toolset.get_tool("read_file")
+
     # Test with non-existent file
     args = {
         "target_file": "nonexistent.txt",
         "should_read_entire_file": True,
         "start_line_one_indexed": 1,
         "end_line_one_indexed_inclusive": 5,
-        "explanation": "Testing error handling"
+        "explanation": "Testing error handling",
     }
-    
+
     result = await tool.run(args, tool_context)
-    
+
     assert isinstance(result, str)
-    assert "Error reading file" in result 
+    assert "Error reading file" in result

--- a/tests/tool/test_registry.py
+++ b/tests/tool/test_registry.py
@@ -8,16 +8,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 from codin.tool.registry import ToolRegistry, ToolRegistryConfig, ToolEndpoint
 from codin.tool.base import Tool, Toolset, ToolContext
-from codin.tool.core_tools import CoreToolset
+from codin.tool.sandbox import SandboxToolset
 from codin.sandbox.local import LocalSandbox
 
 
 class MockTool(Tool):
     """Mock tool for testing."""
-    
+
     def __init__(self, name: str, description: str = "Mock tool"):
         super().__init__(name=name, description=description)
-    
+
     async def run(self, args: dict, tool_context: ToolContext):
         return {"tool": self.name, "args": args}
 
@@ -36,17 +36,17 @@ def sample_config():
     return ToolRegistryConfig(
         endpoints=[
             ToolEndpoint(endpoint="fs://./tools", name="local_tools"),
-            ToolEndpoint(endpoint="http://localhost:8080", name="remote_tools", enabled=False)
+            ToolEndpoint(endpoint="http://localhost:8080", name="remote_tools", enabled=False),
         ],
         tool_prefix_removal=True,
-        auto_initialize=False
+        auto_initialize=False,
     )
 
 
 def test_tool_registry_initialization():
     """Test basic tool registry initialization."""
     registry = ToolRegistry()
-    
+
     assert len(registry.get_tools()) == 0
     assert len(registry.get_toolsets()) == 0
 
@@ -54,7 +54,7 @@ def test_tool_registry_initialization():
 def test_tool_registry_with_config(sample_config):
     """Test tool registry initialization with config."""
     registry = ToolRegistry(sample_config)
-    
+
     assert registry.config == sample_config
     assert registry.config.tool_prefix_removal is True
     assert registry.config.auto_initialize is False
@@ -64,9 +64,9 @@ def test_register_single_tool():
     """Test registering a single tool."""
     registry = ToolRegistry()
     tool = MockTool("test_tool")
-    
+
     registry.register_tool(tool)
-    
+
     assert len(registry.get_tools()) == 1
     assert registry.get_tool("test_tool") == tool
 
@@ -75,10 +75,10 @@ def test_register_single_tool():
 async def test_register_toolset_without_prefix_removal(sandbox):
     """Test registering a toolset without prefix removal."""
     registry = ToolRegistry(ToolRegistryConfig(tool_prefix_removal=False))
-    toolset = CoreToolset(sandbox)
-    
+    toolset = SandboxToolset(sandbox)
+
     registry.register_toolset(toolset)
-    
+
     # Should keep original names with prefixes
     assert registry.get_tool("list_dir") is not None
     assert registry.get_tool("read_file") is not None
@@ -88,14 +88,14 @@ async def test_register_toolset_without_prefix_removal(sandbox):
 def test_register_toolset_with_prefix_removal():
     """Test registering a toolset with prefix removal."""
     registry = ToolRegistry(ToolRegistryConfig(tool_prefix_removal=True))
-    
+
     # Create a mock toolset with prefixed tools
     toolset = Toolset("sandbox", "Mock sandbox toolset")
     toolset.add_tool(MockTool("sandbox_exec"))
     toolset.add_tool(MockTool("sandbox_read"))
-    
+
     registry.register_toolset(toolset)
-    
+
     # Should remove prefixes when no conflicts
     assert registry.get_tool("exec") is not None
     assert registry.get_tool("read") is not None
@@ -105,17 +105,17 @@ def test_register_toolset_with_prefix_removal():
 def test_register_toolset_with_conflicts():
     """Test registering toolsets with naming conflicts."""
     registry = ToolRegistry(ToolRegistryConfig(tool_prefix_removal=True))
-    
+
     # Register first toolset
     toolset1 = Toolset("toolset1", "First toolset")
     toolset1.add_tool(MockTool("toolset1_common"))
     registry.register_toolset(toolset1)
-    
+
     # Register second toolset with conflicting simplified name
     toolset2 = Toolset("toolset2", "Second toolset")
     toolset2.add_tool(MockTool("toolset2_common"))
     registry.register_toolset(toolset2)
-    
+
     # First tool should get simplified name, second should keep prefix
     assert registry.get_tool("common") is not None
     assert registry.get_tool("toolset2_common") is not None
@@ -124,24 +124,25 @@ def test_register_toolset_with_conflicts():
 def test_get_tools_with_executor():
     """Test getting tools wrapped with executor."""
     from codin.tool.executor import ToolExecutor
-    
+
     registry = ToolRegistry()
     tool = MockTool("test_tool")
     registry.register_tool(tool)
-    
+
     # Without executor
     tools = registry.get_tools_with_executor()
     assert len(tools) == 1
     assert tools[0] == tool
-    
+
     # With executor
     executor = ToolExecutor(registry)
     registry.set_executor(executor)
-    
+
     wrapped_tools = registry.get_tools_with_executor()
     assert len(wrapped_tools) == 1
     # Should be wrapped in GenericTool
     from codin.tool.generic import GenericTool
+
     assert isinstance(wrapped_tools[0], GenericTool)
 
 
@@ -149,17 +150,15 @@ def test_get_tools_with_executor():
 async def test_registry_from_config_file():
     """Test creating registry from config file."""
     config_data = {
-        "endpoints": [
-            {"endpoint": "fs://./tools", "name": "local"}
-        ],
+        "endpoints": [{"endpoint": "fs://./tools", "name": "local"}],
         "tool_prefix_removal": True,
-        "auto_initialize": False
+        "auto_initialize": False,
     }
-    
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         json.dump(config_data, f)
         config_path = f.name
-    
+
     try:
         registry = await ToolRegistry.from_config(config_path)
         assert registry.config.tool_prefix_removal is True
@@ -172,7 +171,7 @@ async def test_registry_from_config_file():
 async def test_registry_from_endpoint():
     """Test creating registry from single endpoint."""
     registry = await ToolRegistry.from_endpoint("fs://./tools", name="test")
-    
+
     assert len(registry.config.endpoints) == 1
     assert registry.config.endpoints[0].endpoint == "fs://./tools"
     assert registry.config.endpoints[0].name == "test"
@@ -183,15 +182,16 @@ async def test_up_all_tools(sandbox):
     """Test bringing up all tools in registry."""
     config = ToolRegistryConfig(auto_initialize=True)
     registry = ToolRegistry(config)
-    
-    toolset = CoreToolset(sandbox)
+
+    toolset = SandboxToolset(sandbox)
     registry.register_toolset(toolset)
-    
+
     await registry.up()
-    
+
     # Check that tools are up
     for tool in registry.get_tools():
         from codin.lifecycle import LifecycleState
+
         assert tool.state == LifecycleState.UP
 
 
@@ -199,35 +199,36 @@ async def test_up_all_tools(sandbox):
 async def test_down_all_tools(sandbox):
     """Test bringing down all tools in registry."""
     registry = ToolRegistry()
-    
-    toolset = CoreToolset(sandbox)
+
+    toolset = SandboxToolset(sandbox)
     registry.register_toolset(toolset)
-    
+
     # Bring up first
     await registry.up()
-    
+
     # Then bring down
     await registry.down()
-    
+
     # Check that tools are down
     for tool in registry.get_tools():
         from codin.lifecycle import LifecycleState
+
         assert tool.state == LifecycleState.DOWN
 
 
 def test_tool_overwrite_warning():
     """Test that overwriting tools generates warnings."""
     import logging
-    
+
     registry = ToolRegistry()
     tool1 = MockTool("test_tool", "First tool")
     tool2 = MockTool("test_tool", "Second tool")
-    
+
     registry.register_tool(tool1)
-    
+
     # This should generate a warning (we can't easily test the warning itself)
     registry.register_tool(tool2)
-    
+
     # Second tool should overwrite first
     assert registry.get_tool("test_tool") == tool2
 
@@ -235,16 +236,16 @@ def test_tool_overwrite_warning():
 def test_toolset_overwrite_warning():
     """Test that overwriting toolsets generates warnings."""
     registry = ToolRegistry()
-    
+
     toolset1 = Toolset("test_toolset", "First toolset")
     toolset1.add_tool(MockTool("tool1"))
-    
+
     toolset2 = Toolset("test_toolset", "Second toolset")
     toolset2.add_tool(MockTool("tool2"))
-    
+
     registry.register_toolset(toolset1)
     registry.register_toolset(toolset2)
-    
+
     # Second toolset should overwrite first
     assert registry.get_toolset("test_toolset") == toolset2
     assert registry.get_tool("tool2") is not None
@@ -257,12 +258,10 @@ def test_endpoint_configuration():
     assert endpoint.endpoint == "http://localhost:8080"
     assert endpoint.enabled is True
     assert endpoint.timeout == 30.0
-    
+
     # Endpoint with auth
     endpoint_with_auth = ToolEndpoint(
-        endpoint="http://api.example.com",
-        auth={"type": "bearer", "token": "secret"},
-        timeout=60.0
+        endpoint="http://api.example.com", auth={"type": "bearer", "token": "secret"}, timeout=60.0
     )
     assert endpoint_with_auth.auth["type"] == "bearer"
-    assert endpoint_with_auth.timeout == 60.0 
+    assert endpoint_with_auth.timeout == 60.0


### PR DESCRIPTION
## Summary
- remove CoreToolset and keep only FetchTool
- update tool exports
- switch examples and docs to SandboxToolset
- update tests to rely on SandboxToolset

## Testing
- `make format`
- `make test` *(fails: ImportError while importing test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68441a6889288320aae36041a5ed78ce