### PR TITLE
Fix test imports and circular mailbox import

### DIFF
--- a/src/codin/actor/local_mailbox.py
+++ b/src/codin/actor/local_mailbox.py
@@ -4,7 +4,10 @@ import asyncio
 import typing as _t
 
 from .mailbox import Mailbox
-from ..agent.types import Message
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..agent.types import Message
 
 __all__ = ["LocalMailbox"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,11 @@ import typing as _t
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Ensure 'src.codin' imports refer to local 'codin' package
+# Add the local 'src' directory to sys.path so tests can import the package
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+SRC_DIR = os.path.join(ROOT_DIR, "src")
+sys.path.insert(0, SRC_DIR)
+
 import codin as _codin
 sys.modules.setdefault('src', types.ModuleType('src'))
 sys.modules['src.codin'] = _codin


### PR DESCRIPTION
## Summary
- add `src` path to `sys.path` for tests
- avoid circular import in `LocalMailbox` by only importing Message for typing
- install package and run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441f32934c83208b7b122f3a00e0be