### PR TITLE
Fix mailbox import and improve docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,9 @@ cd codin
 make setup          # Linux/macOS
 .\make.ps1 setup     # Windows
 
+# Alternatively using pip
+python -m pip install -e .[dev]
+
 # Run tests to verify everything works
 make test           # Linux/macOS
 .\make.ps1 test     # Windows

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ cd codin
 # Install with uv (recommended)
 uv sync
 
-# Or install with pip
-pip install -e .
+# Or install with pip (development mode)
+pip install -e .[dev]
 ```
 
 ## Environment Setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ codin = "codin.cli.commands:main"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
+    "pytest>=8.3.5",
+    "pytest-asyncio>=0.26.0",
     "black>=23.0.0",
     "isort>=5.12.0",
     "mypy>=1.0.0",

--- a/src/codin/actor/mailbox.py
+++ b/src/codin/actor/mailbox.py
@@ -7,8 +7,10 @@ import typing as _t
 from abc import ABC, abstractmethod
 
 from typing import TYPE_CHECKING
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..agent.types import Message
+    from .local_mailbox import LocalMailbox as _LocalMailbox
+    from .ray_mailbox import RayMailbox as _RayMailbox
 
 
 __all__ = ["Mailbox", "LocalMailbox", "RayMailbox"]
@@ -50,6 +52,12 @@ class Mailbox(ABC):
         """Iterate over outbox messages."""
 
 
-from .local_mailbox import LocalMailbox
-from .ray_mailbox import RayMailbox
+def __getattr__(name: str):
+    if name == "LocalMailbox":  # pragma: no cover - lazy import
+        from .local_mailbox import LocalMailbox as cls
+        return cls
+    if name == "RayMailbox":  # pragma: no cover - lazy import
+        from .ray_mailbox import RayMailbox as cls
+        return cls
+    raise AttributeError(name)
 

--- a/src/codin/agent/__init__.py
+++ b/src/codin/agent/__init__.py
@@ -95,3 +95,4 @@ __all__ = [
     'get_base_planner',
     'get_code_agent',
 ]
+

--- a/src/codin/sandbox/local.py
+++ b/src/codin/sandbox/local.py
@@ -125,7 +125,7 @@ class LocalSandbox(Sandbox):
     async def _install_dependencies(self, dependencies: list[str], language: str) -> ExecResult:
         """Install dependencies for the given language."""
         if not dependencies:
-            return ExecResult('', '', 0)
+            return ExecResult(stdout='', stderr='', exit_code=0)
 
         language = language.lower()
 
@@ -140,9 +140,9 @@ class LocalSandbox(Sandbox):
             cmd = ['go', 'get'] + dependencies
         elif language == 'rust':
             # For Rust, dependencies should be in Cargo.toml
-            return ExecResult('', 'Rust dependencies should be specified in Cargo.toml', 1)
+            return ExecResult(stdout='', stderr='Rust dependencies should be specified in Cargo.toml', exit_code=1)
         else:
-            return ExecResult('', f'Dependency installation not supported for {language}', 1)
+            return ExecResult(stdout='', stderr=f'Dependency installation not supported for {language}', exit_code=1)
 
         return await self.run_cmd(cmd)
 
@@ -204,11 +204,11 @@ class LocalSandbox(Sandbox):
                 )
             try:
                 stdout, stderr = proc.communicate(timeout=timeout)
-                return ExecResult(stdout, stderr, exit_code=proc.returncode)
+                return ExecResult(stdout=stdout, stderr=stderr, exit_code=proc.returncode)
             except subprocess.TimeoutExpired:
                 proc.kill()
                 stdout, stderr = proc.communicate()
-                return ExecResult(stdout, stderr, exit_code=-1)
+                return ExecResult(stdout=stdout, stderr=stderr, exit_code=-1)
 
         # Run the blocking operation in a thread pool
         return await loop.run_in_executor(None, _run_subprocess)
@@ -225,17 +225,19 @@ class LocalSandbox(Sandbox):
     ) -> ExecResult:
         """Execute code in the sandbox."""
         if not code and not file_path:
-            return ExecResult('', 'Either code or file_path must be provided', 1)
+            return ExecResult(stdout='', stderr='Either code or file_path must be provided', exit_code=1)
 
         if code and file_path:
-            return ExecResult('', 'Cannot provide both code and file_path', 1)
+            return ExecResult(stdout='', stderr='Cannot provide both code and file_path', exit_code=1)
 
         # Install dependencies first if provided
         if dependencies:
             dep_result = await self._install_dependencies(dependencies, language)
             if dep_result.exit_code != 0:
                 return ExecResult(
-                    dep_result.stdout, f'Failed to install dependencies: {dep_result.stderr}', dep_result.exit_code
+                    stdout=dep_result.stdout,
+                    stderr=f'Failed to install dependencies: {dep_result.stderr}',
+                    exit_code=dep_result.exit_code,
                 )
 
         # Handle direct code execution
@@ -281,14 +283,14 @@ class LocalSandbox(Sandbox):
                 return await self.run_cmd(cmd, timeout=timeout, env=env)
 
             except (ValueError, NotImplementedError) as e:
-                return ExecResult('', str(e), 1)
+                return ExecResult(stdout='', stderr=str(e), exit_code=1)
 
         # Handle file path execution
         if file_path:
             file_path = Path(file_path)
 
             if not file_path.exists():
-                return ExecResult('', f'File not found: {file_path}', 1)
+                return ExecResult(stdout='', stderr=f'File not found: {file_path}', exit_code=1)
 
             # Create a temporary directory for execution
             with tempfile.TemporaryDirectory() as temp_dir:
@@ -310,11 +312,15 @@ class LocalSandbox(Sandbox):
 
                             main_file = self._get_main_file_for_language(language, all_files)
                             if not main_file:
-                                return ExecResult('', f'No main file found for language {language}', 1)
+                                return ExecResult(
+                                    stdout='',
+                                    stderr=f'No main file found for language {language}',
+                                    exit_code=1,
+                                )
 
                             exec_path = temp_path / main_file
                         except zipfile.BadZipFile:
-                            return ExecResult('', f'Invalid zip file: {file_path}', 1)
+                            return ExecResult(stdout='', stderr=f'Invalid zip file: {file_path}', exit_code=1)
                     else:
                         # Copy single file
                         exec_path = temp_path / file_path.name
@@ -336,12 +342,12 @@ class LocalSandbox(Sandbox):
 
                     main_file = self._get_main_file_for_language(language, all_files)
                     if not main_file:
-                        return ExecResult('', f'No main file found for language {language}', 1)
+                        return ExecResult(stdout='', stderr=f'No main file found for language {language}', exit_code=1)
 
                     exec_path = search_path / main_file
 
                 else:
-                    return ExecResult('', f'Invalid file path: {file_path}', 1)
+                    return ExecResult(stdout='', stderr=f'Invalid file path: {file_path}', exit_code=1)
 
                 # Execute the file
                 try:
@@ -349,7 +355,7 @@ class LocalSandbox(Sandbox):
                     cmd = executor + [str(exec_path)]
                     return await self.run_cmd(cmd, cwd=str(exec_path.parent), timeout=timeout, env=env)
                 except (ValueError, NotImplementedError) as e:
-                    return ExecResult('', str(e), 1)
+                    return ExecResult(stdout='', stderr=str(e), exit_code=1)
 
     # Filesystem -----------------------------------------------------------
     def _abs(self, path: str) -> str:

--- a/tests/agent/test_base_planner.py
+++ b/tests/agent/test_base_planner.py
@@ -1,5 +1,6 @@
 import pytest
 
+import codin.agent.base_planner as base_planner
 from codin.agent.base_planner import BasePlanner
 from codin.agent.types import ErrorStep, FinishStep, State
 
@@ -11,7 +12,7 @@ async def test_error_step_emitted(monkeypatch):
     async def fail_prompt_run(*args, **kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr("codin.agent.base_planner.prompt_run", fail_prompt_run)
+    monkeypatch.setattr(base_planner, "prompt_run", fail_prompt_run)
 
     planner = BasePlanner()
     state = State.model_construct(session_id="s2")

--- a/tests/cli/test_repl_instructions.py
+++ b/tests/cli/test_repl_instructions.py
@@ -1,0 +1,17 @@
+import pytest
+from codin.cli.repl import ReplSession
+
+
+def test_load_project_instructions(monkeypatch):
+    monkeypatch.setattr(
+        "codin.cli.repl.load_agents_instructions",
+        lambda: "Sample instructions",
+    )
+    session = ReplSession(verbose=False, debug=False)
+    assert session.load_project_instructions() == "Sample instructions"
+
+
+def test_load_project_instructions_disabled(monkeypatch):
+    session = ReplSession(verbose=False, debug=False)
+    session.config.enable_rules = False
+    assert session.load_project_instructions() is None

--- a/tests/tool/test_core_tools.py
+++ b/tests/tool/test_core_tools.py
@@ -198,7 +198,7 @@ async def test_edit_file_tool(sandbox_toolset, sandbox, tool_context):
 
 
 @pytest.mark.asyncio
-async def test_search_replace_tool(sandbox, tool_context):
+async def test_search_replace_tool(sandbox_toolset, sandbox, tool_context):
     """Test SearchReplaceTool functionality."""
     # Create a test file
     await sandbox.write_file("test_replace.txt", "Line 1\nLine 2\nLine 3")


### PR DESCRIPTION
## Summary
- fix circular import in `Mailbox` module via lazy imports
- sync dev dependency versions and include `pytest-asyncio`
- document `pip install -e .[dev]` in README and CONTRIBUTING
- add regression tests for REPL instructions
- ensure tests run by fixing memory service API, sandbox exec results, and patching module aliases
- remove leftover base_planner alias and adjust tests

## Testing
- `ruff check src/codin/agent/__init__.py tests/agent/test_base_planner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441f4c79188320a58fb0cfc58cea0d