### PR TITLE
Update LocalMailbox for multi-message queues

### DIFF
--- a/src/codin/actor/local_mailbox.py
+++ b/src/codin/actor/local_mailbox.py
@@ -26,8 +26,6 @@ class LocalMailbox(Mailbox):
             msgs = [msgs]
         for msg in msgs:
             if timeout is None:
-                while not q.empty():
-                    await asyncio.sleep(0)
                 await q.put(msg)
             else:
                 await asyncio.wait_for(q.put(msg), timeout=timeout)

--- a/tests/actor/mailbox_test.py
+++ b/tests/actor/mailbox_test.py
@@ -53,6 +53,44 @@ async def test_local_mailbox():
     received_out = (await mailbox.get_outbox(timeout=1.0))[0]
     assert received_out.messageId == "msg2"
 
+    # Queues can hold multiple messages
+    msg3 = Message(
+        messageId="msg3",
+        role=Role.user,
+        parts=[TextPart(text="More")],
+        contextId="test",
+        kind="message",
+    )
+    msg4 = Message(
+        messageId="msg4",
+        role=Role.user,
+        parts=[TextPart(text="Data")],
+        contextId="test",
+        kind="message",
+    )
+    await mailbox.put_inbox(msg3)
+    await mailbox.put_inbox(msg4)
+    received_many = await mailbox.get_inbox(max_messages=2, timeout=1.0)
+    assert [m.messageId for m in received_many] == ["msg3", "msg4"]
+
+    msg5 = Message(
+        messageId="msg5",
+        role=Role.agent,
+        parts=[TextPart(text="More")],
+        contextId="test",
+        kind="message",
+    )
+    msg6 = Message(
+        messageId="msg6",
+        role=Role.agent,
+        parts=[TextPart(text="Data")],
+        contextId="test",
+        kind="message",
+    )
+    await mailbox.put_outbox([msg5, msg6])
+    received_many_out = await mailbox.get_outbox(max_messages=2, timeout=1.0)
+    assert [m.messageId for m in received_many_out] == ["msg5", "msg6"]
+
 
 @pytest.mark.asyncio
 async def test_local_actor_manager():


### PR DESCRIPTION
## Summary
- allow `LocalMailbox` to queue multiple messages without waiting for the queue to empty
- add tests for multiple inbox/outbox messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844281891548320b2c26d07ef64eb58