### PR TITLE
Run multiple agents concurrently

### DIFF
--- a/src/codin/actor/dispatcher.py
+++ b/src/codin/actor/dispatcher.py
@@ -149,19 +149,25 @@ class LocalDispatcher(Dispatcher):
             # Create message from A2A data
             message = self._create_message_from_a2a(message_data, context_id)
 
-            # Determine which agents to create (for now, create a single main agent)
+            # Determine which agents to create (allows override via attribute for tests)
             # In the future, this could parse the request to determine multiple agents
-            agents_to_create = [
-                ('main_agent', context_id),
-                # Could add: ("planner_agent", context_id), ("executor_agent", context_id)
-            ]
+            agents_to_create = getattr(
+                self,
+                'agents_to_create',
+                [
+                    ('main_agent', context_id),
+                    # Could add: ("planner_agent", context_id), ("executor_agent", context_id)
+                ],
+            )
 
             # Create agents through actor manager
             agents: list[Agent] = []
             for agent_type, key in agents_to_create:
                 agent = await self.actor_manager.acquire(agent_type, key)
                 agents.append(agent)
-                result.agents.append(agent.agent_id if hasattr(agent, 'agent_id') else f'{agent_type}:{key}')
+                result.agents.append(
+                    agent.agent_id if hasattr(agent, 'agent_id') else f'{agent_type}:{key}'
+                )
 
             # Create agent run input
             from ..agent.types import AgentRunInput
@@ -170,26 +176,19 @@ class LocalDispatcher(Dispatcher):
                 id=request.request_id, message=message, session_id=context_id, metadata=request.metadata
             )
 
-            # Run the main agent (could be extended to orchestrate multiple agents)
-            main_agent = agents[0]
-            async for output in main_agent.run(run_input):
-                # enqueue output for subscribers
-                await stream_queue.put(
-                    output.dict() if hasattr(output, 'dict') else str(output)
-                )
+            # Run all agents concurrently
+            tasks = [
+                asyncio.create_task(self._run_agent(a, run_input, stream_queue, result))
+                for a in agents
+            ]
+            errors = await asyncio.gather(*tasks, return_exceptions=True)
 
-                # also keep history in metadata
-                if 'outputs' not in result.metadata:
-                    result.metadata['outputs'] = []
-                result.metadata['outputs'].append(
-                    {
-                        'timestamp': datetime.now().isoformat(),
-                        'output': output.dict() if hasattr(output, 'dict') else str(output),
-                    }
-                )
-
-            # Mark as completed
-            result.status = 'completed'
+            exceptions = [e for e in errors if isinstance(e, Exception)]
+            if exceptions:
+                result.status = 'failed'
+                result.metadata['errors'] = [str(e) for e in exceptions]
+            else:
+                result.status = 'completed'
 
         except Exception as e:
             # Mark as failed
@@ -206,6 +205,28 @@ class LocalDispatcher(Dispatcher):
                 del self._run_tasks[result.runner_id]
             if result.runner_id in self._run_streams:
                 del self._run_streams[result.runner_id]
+
+    async def _run_agent(
+        self,
+        agent: 'Agent',
+        run_input: 'AgentRunInput',
+        stream_queue: asyncio.Queue,
+        result: DispatchResult,
+    ) -> None:
+        """Iterate over agent.run and enqueue outputs."""
+        async for output in agent.run(run_input):
+            await stream_queue.put(
+                output.dict() if hasattr(output, 'dict') else str(output)
+            )
+
+            if 'outputs' not in result.metadata:
+                result.metadata['outputs'] = []
+            result.metadata['outputs'].append(
+                {
+                    'timestamp': datetime.now().isoformat(),
+                    'output': output.dict() if hasattr(output, 'dict') else str(output),
+                }
+            )
 
     def _create_message_from_a2a(self, message_data: dict, context_id: str) -> Message:
         """Create a Message object from A2A message data."""

--- a/tests/actor/test_dispatcher_multiagent.py
+++ b/tests/actor/test_dispatcher_multiagent.py
@@ -1,0 +1,84 @@
+import asyncio
+import time
+import pytest
+import codin.actor.supervisor as scheduler
+
+from codin.actor.dispatcher import LocalDispatcher
+from codin.actor.supervisor import LocalActorManager, ActorInfo
+from codin.agent.base_agent import BaseAgent
+from codin.agent.base import Planner
+from codin.agent.types import AgentRunInput, AgentRunOutput, Message, TextPart, Role
+
+
+class DummyPlanner(Planner):
+    async def next(self, state):
+        if False:
+            yield  # pragma: no cover
+
+    async def reset(self, state):
+        pass
+
+
+class SleepAgent(BaseAgent):
+    async def run(self, input_data: AgentRunInput):
+        await asyncio.sleep(0.5)
+        yield AgentRunOutput(
+            id="1",
+            result=Message(
+                messageId="m",
+                role=Role.agent,
+                parts=[TextPart(text=self.agent_id)],
+                contextId=input_data.session_id or "ctx",
+                kind="message",
+            ),
+        )
+
+
+async def factory(agent_type: str, key: str) -> BaseAgent:
+    return SleepAgent(agent_id=f"{agent_type}:{key}", name=agent_type, description="d", planner=DummyPlanner())
+
+
+def message_converter(self, data: dict, ctx: str) -> Message:
+    return Message(
+        messageId=data.get("messageId"),
+        role=Role(data.get("role", "user")),
+        parts=[TextPart(text=data.get("parts", [{"text": ""}])[0]["text"])],
+        contextId=ctx,
+        kind="message",
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiple_agents_concurrent():
+    scheduler.Agent = BaseAgent
+    ActorInfo.model_rebuild()
+    manager = LocalActorManager(agent_factory=factory)
+    dispatcher = LocalDispatcher(manager)
+    dispatcher._create_message_from_a2a = message_converter.__get__(dispatcher, LocalDispatcher)
+    dispatcher.agents_to_create = [("a1", "ctx"), ("a2", "ctx")]
+
+    a2a_request = {
+        "contextId": "ctx",
+        "message": {
+            "messageId": "u1",
+            "role": "user",
+            "parts": [{"kind": "text", "text": "hi"}],
+            "kind": "message",
+        },
+    }
+
+    start = time.monotonic()
+    runner_id = await dispatcher.submit(a2a_request)
+    while True:
+        status = await dispatcher.get_status(runner_id)
+        if status.status != "started":
+            break
+        await asyncio.sleep(0.1)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0
+    outputs = status.metadata["outputs"]
+    assert len(outputs) == 2
+    texts = {o["output"]["result"]["parts"][0]["text"] for o in outputs}
+    assert texts == {"a1:ctx", "a2:ctx"}
+


### PR DESCRIPTION
## Summary
- allow overriding dispatcher agent list
- run agents concurrently via `_run_agent`
- add `_run_agent` helper
- test concurrent dispatch of multiple agents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68442821e04c8320b34b943c865319f3