### PR TITLE
Add task start/end events

### DIFF
--- a/docs/debug_events.md
+++ b/docs/debug_events.md
@@ -128,6 +128,26 @@ async def my_debug_handler(event):
 agent.add_event_callback(my_debug_handler)
 ```
 
+## Task Events
+
+Two additional events provide high-level progress information:
+
+- `task_start` - emitted when a task begins.
+- `task_end` - emitted when the task finishes.
+
+Both events include the following fields:
+
+```python
+{
+    "session_id": str,   # Conversation/session identifier
+    "iteration": int,    # Current iteration when the event was emitted
+    "elapsed_time": float  # Seconds since the task started
+}
+```
+
+Event listeners registered via `add_event_callback` receive these events the same
+way as `debug_llm_response`.
+
 ## Migration
 
 The previous direct print-based debug system has been completely replaced with this event-based approach. No breaking changes were made to the public API - the `debug` parameter still works the same way, but the implementation is now cleaner and more flexible. 

--- a/src/codin/agent/base_agent.py
+++ b/src/codin/agent/base_agent.py
@@ -313,6 +313,15 @@ class BaseAgent(Agent):
         self, state: State, session_id: str, start_time: float
     ) -> _t.AsyncGenerator[AgentRunOutput]:
         """Execute planning loop with budget constraints and control handling."""
+
+        await self._emit_event(
+            'task_start',
+            {
+                'session_id': session_id,
+                'iteration': state.iteration,
+                'elapsed_time': 0.0,
+            },
+        )
         while state.iteration < (state.config.turn_budget or 100):
             # Check for control messages and handle pause/cancel states
             should_continue = await self.check_inbox_for_control()
@@ -439,6 +448,15 @@ class BaseAgent(Agent):
                     id=str(uuid.uuid4()), result=error_msg, metadata={'error': str(e), 'agent_id': self.id}
                 )
                 break
+
+        await self._emit_event(
+            'task_end',
+            {
+                'session_id': session_id,
+                'iteration': state.iteration,
+                'elapsed_time': time.time() - start_time,
+            },
+        )
 
     async def _execute_step(self, step: Step, state: State, session_id: str) -> _t.AsyncGenerator[AgentRunOutput]:
         """Execute step using codin components and send outputs to mailbox."""

--- a/src/codin/agent/code_agent.py
+++ b/src/codin/agent/code_agent.py
@@ -960,7 +960,14 @@ class CodeAgent(Agent):
         iteration = 0
 
         await self._emit_event(
-            'task_start', {'task_id': task_id, 'user_input': self._extract_text_from_message(input_data.message)}
+            'task_start',
+            {
+                'task_id': task_id,
+                'session_id': self._context_id,
+                'iteration': 0,
+                'elapsed_time': 0.0,
+                'user_input': self._extract_text_from_message(input_data.message),
+            },
         )
 
         try:
@@ -1043,6 +1050,16 @@ class CodeAgent(Agent):
                 except Exception as e:
                     logger.warning(f'Failed to store conversation in memory: {e}')
 
+            await self._emit_event(
+                'task_end',
+                {
+                    'task_id': task_id,
+                    'session_id': self._context_id,
+                    'iteration': iteration,
+                    'elapsed_time': time.time() - self._start_time,
+                },
+            )
+
             return AgentRunOutput(
                 result=final_response,
                 metadata={
@@ -1060,6 +1077,15 @@ class CodeAgent(Agent):
 
             # Return error response
             error_response = self._create_agent_message(f'I encountered an error: {e!s}', task_id)
+            await self._emit_event(
+                'task_end',
+                {
+                    'task_id': task_id,
+                    'session_id': self._context_id,
+                    'iteration': iteration,
+                    'elapsed_time': time.time() - self._start_time,
+                },
+            )
             return AgentRunOutput(
                 result=error_response,
                 metadata={


### PR DESCRIPTION
## Summary
- emit `task_start` and `task_end` in `BaseAgent._execute_planning_loop`
- include session id, iteration, and elapsed time in these events
- emit matching events from `CodeAgent.run`
- document new events in `docs/debug_events.md`

## Testing
- `pip install pyyaml`
- `pip install pydantic`
- `pytest -q` *(fails: ModuleNotFoundError, AttributeError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844283215cc83208f1c7b7d585383e4