### PR TITLE
Add session context manager and docs

### DIFF
--- a/docs/session_manager.md
+++ b/docs/session_manager.md
@@ -1,0 +1,16 @@
+# SessionManager Helper
+
+`SessionManager` now exposes a small asynchronous context manager to simplify
+working with short lived sessions. Use `async with session_manager.session(id)`
+to create or retrieve a session and ensure it is cleaned up on exit.
+
+```python
+from codin.session import SessionManager
+
+manager = SessionManager()
+async with manager.session("demo") as session:
+    # run agent logic with this session
+    ...
+# session is automatically closed
+```
+

--- a/src/codin/agent/runner.py
+++ b/src/codin/agent/runner.py
@@ -67,9 +67,8 @@ class AgentRunner:
                 continue
 
             session_id = msg.contextId or f"session_{uuid.uuid4().hex[:8]}"
-            await self.session_manager.get_or_create_session(session_id)
-
-            agent_input = AgentRunInput(message=msg, session_id=session_id)
-            async for _ in self.agent.run(agent_input):
-                pass
-            await asyncio.sleep(0)
+            async with self.session_manager.session(session_id):
+                agent_input = AgentRunInput(message=msg, session_id=session_id)
+                async for _ in self.agent.run(agent_input):
+                    pass
+                await asyncio.sleep(0)

--- a/tests/session/test_session_context.py
+++ b/tests/session/test_session_context.py
@@ -1,0 +1,18 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_session_context_manager():
+    sys.modules['src.codin.agent.types'] = types.SimpleNamespace(State=object)
+    SessionManager = importlib.import_module('src.codin.session.base').SessionManager
+    mgr = SessionManager()
+    async with mgr.session('s1') as session:
+        assert session.session_id == 's1'
+        assert mgr.get_session('s1') is not None
+    # After context exit the session should be removed
+    assert mgr.get_session('s1') is None
+


### PR DESCRIPTION
## Summary
- add `SessionManager.session` async context manager for automatic cleanup
- use the helper in `AgentRunner`
- document the helper in `docs/session_manager.md`
- add unit test for the new context manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442f8dcf088320bacef0ddcb75bd71