### PR TITLE
Add run_end event

### DIFF
--- a/docs/debug_events.md
+++ b/docs/debug_events.md
@@ -148,6 +148,22 @@ Both events include the following fields:
 Event listeners registered via `add_event_callback` receive these events the same
 way as `debug_llm_response`.
 
+## Run Events
+
+When using the simplified planning loop, the agent emits a `run_end` event after
+the planning loop completes and all cleanup steps finish. This allows external
+systems to know when an agent run has fully finished.
+
+The event data includes:
+
+```python
+{
+    "agent_id": str,
+    "session_id": str,
+    "elapsed_time": float  # Total runtime in seconds
+}
+```
+
 ## Migration
 
 The previous direct print-based debug system has been completely replaced with this event-based approach. No breaking changes were made to the public API - the `debug` parameter still works the same way, but the implementation is now cleaner and more flexible. 

--- a/src/codin/agent/base_agent.py
+++ b/src/codin/agent/base_agent.py
@@ -232,6 +232,17 @@ class BaseAgent(Agent):
                 id=str(uuid.uuid4()), result=error_message, metadata={'error': str(e), 'agent_id': self.id}
             )
 
+        finally:
+            await self.cleanup()
+            await self._emit_event(
+                'run_end',
+                {
+                    'agent_id': self.id,
+                    'session_id': session_id,
+                    'elapsed_time': time.time() - start_time,
+                },
+            )
+
     async def _build_state(self, session_id: str, input_data: AgentRunInput) -> State:
         """Build state using simple memory and components."""
         # Set the session ID in memory if it's MemMemoryService

--- a/tests/agent/test_run_end_event.py
+++ b/tests/agent/test_run_end_event.py
@@ -1,0 +1,46 @@
+import asyncio
+import pytest
+from codin.agent.base_agent import BaseAgent
+from codin.agent.base import Planner
+from codin.agent.types import AgentRunInput, Message, TextPart, Role, FinishStep
+from codin.actor.mailbox import LocalMailbox
+
+class FinishPlanner(Planner):
+    async def next(self, state):
+        yield FinishStep(step_id="finish")
+    async def reset(self, state):
+        pass
+
+@pytest.mark.asyncio
+async def test_run_end_event_emitted():
+    mailbox = LocalMailbox()
+    agent = BaseAgent(
+        name="TestAgent",
+        description="test",
+        planner=FinishPlanner(),
+        mailbox=mailbox,
+    )
+
+    user_msg = Message(
+        messageId="u1",
+        role=Role.user,
+        parts=[TextPart(text="hi")],
+        contextId="sess",
+        kind="message",
+    )
+    input_data = AgentRunInput(message=user_msg, session_id="sess")
+
+    async for _ in agent.run(input_data):
+        pass
+
+    events = []
+    try:
+        while True:
+            msgs = await mailbox.get_outbox(timeout=0.1)
+            for m in msgs:
+                if m.metadata and m.metadata.get("event_type"):
+                    events.append(m.metadata["event_type"])
+    except asyncio.TimeoutError:
+        pass
+
+    assert "run_end" in events


### PR DESCRIPTION
## Summary
- emit `run_end` after cleanup in BaseAgent
- document new `run_end` event
- test event emission

## Testing
- `pytest -q tests/agent/test_run_end_event.py`

------
https://chatgpt.com/codex/tasks/task_e_68442f97c35c8320a8e12c656f03a3c2