### PR TITLE
Run ruff auto-fix on src

### DIFF
--- a/src/codin/actor/dispatcher.py
+++ b/src/codin/actor/dispatcher.py
@@ -5,21 +5,24 @@ to appropriate agents, managing agent lifecycles, and coordinating
 multi-agent workflows in the codin framework.
 """
 
+from __future__ import annotations
+
 import asyncio
 import typing as _t
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
 
-from ..agent.types import Message, Role, TextPart
-from .utils import make_message
 from pydantic import BaseModel, Field
 
+from ..agent.types import Message, Role, TextPart
 from .mailbox import Mailbox
 from .supervisor import ActorSupervisor
+from .utils import make_message
 
 if _t.TYPE_CHECKING:
     from ..agent.base import Agent
+    from ..agent.types import AgentRunInput
 
 __all__ = [
     'DispatchRequest',
@@ -182,8 +185,8 @@ class LocalDispatcher(Dispatcher):
             )
 
             # Start runners for all agents and run them concurrently
-            from ..agent.runner import AgentRunner
             from ..agent.concurrent_runner import ConcurrentRunner
+            from ..agent.runner import AgentRunner
 
             runner_group = ConcurrentRunner()
             for agent in agents:
@@ -228,8 +231,8 @@ class LocalDispatcher(Dispatcher):
 
     async def _run_agent(
         self,
-        agent: 'Agent',
-        run_input: 'AgentRunInput',
+        agent: Agent,
+        run_input: AgentRunInput,
         stream_queue: asyncio.Queue,
         result: DispatchResult,
     ) -> None:
@@ -250,8 +253,8 @@ class LocalDispatcher(Dispatcher):
 
     async def _run_agent_with_semaphore(
         self,
-        agent: 'Agent',
-        run_input: 'AgentRunInput',
+        agent: Agent,
+        run_input: AgentRunInput,
         stream_queue: asyncio.Queue,
         result: DispatchResult,
     ) -> None:

--- a/src/codin/actor/mailbox.py
+++ b/src/codin/actor/mailbox.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import typing as _t
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
+
 from .local_mailbox import LocalMailbox
 from .ray_mailbox import RayMailbox
 
 if TYPE_CHECKING:
 
     from ..agent.types import Message
-    from .local_mailbox import LocalMailbox as _LocalMailbox
-    from .ray_mailbox import RayMailbox as _RayMailbox
 
 
 __all__ = ["Mailbox", "LocalMailbox", "RayMailbox"]

--- a/src/codin/actor/utils.py
+++ b/src/codin/actor/utils.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import uuid
-import typing as _t
 
 from ..agent.types import Message, Role, TextPart
 

--- a/src/codin/agent/__init__.py
+++ b/src/codin/agent/__init__.py
@@ -10,8 +10,8 @@ from ..memory.base import MemMemoryService, Memory
 from ..model.base import BaseLLM
 from ..tool.base import Tool
 from .base import Agent, Planner
-from .runner import AgentRunner
 from .concurrent_runner import ConcurrentRunner
+from .runner import AgentRunner
 
 # Import new architecture types
 from .types import (

--- a/src/codin/agent/concurrent_runner.py
+++ b/src/codin/agent/concurrent_runner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import List
 
 from .runner import AgentRunner
 
@@ -12,10 +11,10 @@ class ConcurrentRunner:
     """Manage a group of :class:`AgentRunner` instances."""
 
     def __init__(self) -> None:
-        self._runners: List[AgentRunner] = []
+        self._runners: list[AgentRunner] = []
 
     @property
-    def runners(self) -> List[AgentRunner]:
+    def runners(self) -> list[AgentRunner]:
         """Return the managed runners."""
         return self._runners
 

--- a/src/codin/session/base.py
+++ b/src/codin/session/base.py
@@ -8,7 +8,9 @@ import asyncio
 import typing as _t
 from contextlib import asynccontextmanager
 from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict, Field
+
 from codin.replay.base import ReplayService
 
 from ..agent.types import State
@@ -192,7 +194,7 @@ class SessionManager:
     @asynccontextmanager
     async def session(
         self, session_id: str, memory_system: MemoryService | None = None
-    ) -> _t.AsyncGenerator[Session, None]:
+    ) -> _t.AsyncGenerator[Session]:
         """Context manager to manage a session's lifecycle.
 
         Creates or retrieves the session and ensures it is closed when the


### PR DESCRIPTION
## Summary
- lint src/codin with ruff
- add `from __future__ import annotations` and import `AgentRunInput` for forward references
- cleanup unused imports and apply typing generics

## Testing
- `ruff check src/codin --fix`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'a2a')*


------
https://chatgpt.com/codex/tasks/task_e_6844338c7818832083f8af771780842d