### PR TITLE
Implement ActorSystem for queued concurrency

### DIFF
--- a/src/codin/actor/__init__.py
+++ b/src/codin/actor/__init__.py
@@ -5,6 +5,7 @@ including mailboxes for message passing, schedulers for task coordination,
 and dispatchers for routing requests between agents.
 """
 
+from .actor_system import ActorSystem
 from .dispatcher import Dispatcher, DispatchRequest, DispatchResult, LocalDispatcher
 from .mailbox import LocalMailbox, Mailbox, RayMailbox
 from .ray_scheduler import RayActorManager
@@ -25,4 +26,5 @@ __all__ = [
     'LocalDispatcher',
     'DispatchRequest',
     'DispatchResult',
+    'ActorSystem',
 ]

--- a/src/codin/actor/actor_system.py
+++ b/src/codin/actor/actor_system.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any
+
+from ..lifecycle import LifecycleMixin
+from .dispatcher import (
+    Dispatcher,  # for typing
+)
+from .supervisor import ActorSupervisor
+
+__all__ = ["ActorSystem"]
+
+
+class ActorSystem(LifecycleMixin):
+    """Simple concurrent actor system handling queued requests."""
+
+    def __init__(
+        self,
+        dispatcher: Dispatcher,
+        actor_manager: ActorSupervisor,
+        *,
+        workers: int = 4,
+    ) -> None:
+        super().__init__()
+        self.dispatcher = dispatcher
+        self.actor_manager = actor_manager
+        self.workers = workers
+        self._queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+        self._tasks: list[asyncio.Task] = []
+
+    async def submit(self, request: dict[str, Any]) -> asyncio.Future:
+        """Enqueue an A2A request and return a future with the runner id."""
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[str] = loop.create_future()
+        await self._queue.put({"request": request, "future": fut})
+        return fut
+
+    async def _worker(self) -> None:
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                break
+            request = item["request"]
+            fut: asyncio.Future = item["future"]
+            try:
+                runner_id = await self.dispatcher.submit(request)
+            except Exception as exc:
+                fut.set_exception(exc)
+            else:
+                fut.set_result(runner_id)
+
+    async def _up(self) -> None:
+        for _ in range(self.workers):
+            self._tasks.append(asyncio.create_task(self._worker()))
+
+    async def _down(self) -> None:
+        for _ in self._tasks:
+            await self._queue.put(None)
+        for task in self._tasks:
+            with contextlib.suppress(Exception):
+                await task
+        self._tasks.clear()
+        # flush queue
+        while not self._queue.empty():
+            self._queue.get_nowait()
+            self._queue.task_done()

--- a/tests/actor/test_actor_system.py
+++ b/tests/actor/test_actor_system.py
@@ -1,0 +1,94 @@
+import asyncio
+import time
+
+import pytest
+
+from codin.actor.actor_system import ActorSystem
+from codin.actor.dispatcher import LocalDispatcher
+from codin.actor.supervisor import ActorInfo, LocalActorManager
+from codin.agent.base import Planner
+from codin.agent.base_agent import BaseAgent
+from codin.agent.types import AgentRunInput, AgentRunOutput, Message, Role, TextPart
+
+
+class DummyPlanner(Planner):
+    async def next(self, state):
+        if False:
+            yield
+
+    async def reset(self, state):
+        pass
+
+
+class SleepAgent(BaseAgent):
+    async def run(self, input_data: AgentRunInput):
+        await asyncio.sleep(0.5)
+        yield AgentRunOutput(
+            id="1",
+            result=Message(
+                messageId="m",
+                role=Role.agent,
+                parts=[TextPart(text=self.agent_id)],
+                contextId=input_data.session_id or "ctx",
+                kind="message",
+            ),
+        )
+
+
+async def factory(agent_type: str, key: str) -> BaseAgent:
+    return SleepAgent(agent_id=f"{agent_type}:{key}", name=agent_type, description="d", planner=DummyPlanner())
+
+
+def message_converter(self, data: dict, ctx: str) -> Message:
+    return Message(
+        messageId=data.get("messageId"),
+        role=Role(data.get("role", "user")),
+        parts=[TextPart(text=data.get("parts", [{"text": ""}])[0]["text"])],
+        contextId=ctx,
+        kind="message",
+    )
+
+
+@pytest.mark.asyncio
+async def test_actor_system_parallel():
+    import codin.actor.supervisor as scheduler
+    scheduler.Agent = BaseAgent
+    ActorInfo.model_rebuild()
+    manager = LocalActorManager(agent_factory=factory)
+    dispatcher = LocalDispatcher(manager)
+    dispatcher._create_message_from_a2a = message_converter.__get__(dispatcher, LocalDispatcher)
+    dispatcher.agents_to_create = [("a", "ctx")]
+    system = ActorSystem(dispatcher, manager, workers=2)
+    await system.up()
+
+    a2a_request = {
+        "contextId": "ctx",
+        "message": {
+            "messageId": "u1",
+            "role": "user",
+            "parts": [{"kind": "text", "text": "hi"}],
+            "kind": "message",
+        },
+    }
+
+    start = time.monotonic()
+    fut1 = await system.submit(a2a_request)
+    fut2 = await system.submit(a2a_request)
+    rid1 = await fut1
+    rid2 = await fut2
+
+    async def wait_done(rid):
+        while True:
+            status = await dispatcher.get_status(rid)
+            if status.status != "started":
+                return status
+            await asyncio.sleep(0.05)
+
+    s1, s2 = await asyncio.gather(wait_done(rid1), wait_done(rid2))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0
+    assert s1.status == "completed"
+    assert s2.status == "completed"
+
+    await system.down()


### PR DESCRIPTION
## Summary
- add `ActorSystem` providing a simple queued worker system for dispatching A2A requests concurrently
- export `ActorSystem` from `codin.actor`
- test the new actor system

## Testing
- `pytest tests/actor/test_actor_system.py::test_actor_system_parallel -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e18c4888832095eb3877cbed6131