### PR TITLE
Fix ActorInfo model rebuild

### DIFF
--- a/src/codin/actor/supervisor.py
+++ b/src/codin/actor/supervisor.py
@@ -13,6 +13,11 @@ from pydantic import BaseModel, Field
 
 if _t.TYPE_CHECKING:
     from ..agent.base import Agent
+else:  # pragma: no cover - runtime fallback for forward refs
+    try:  # avoid import cycle during runtime import
+        from ..agent.base import Agent
+    except Exception:  # noqa: BLE001 - best effort fallback
+        Agent = _t.Any
 
 __all__ = [
     'ActorInfo',


### PR DESCRIPTION
## Summary
- avoid ActorInfo model rebuild failure by providing a runtime fallback for `Agent`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6844e45470d083208cc22e7e1b3ade74