### PR TITLE
Add SearchAgent metadata override

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ agent = BaseAgent(
 
 # Execute task
 from codin.agent.types import AgentRunInput, Message
-from a2a.types import Role, TextPart
+from codin.agent.types import Role, TextPart
 
 task_message = Message(
     messageId="task-1",

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -25,7 +25,7 @@ from pathlib import Path
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from a2a.types import Role, TextPart
+from codin.agent.types import Role, TextPart
 
 from codin.agent.base_agent import BaseAgent
 from codin.agent.code_planner import CodePlanner, CodePlannerConfig

--- a/examples/hello_world_test.py
+++ b/examples/hello_world_test.py
@@ -17,7 +17,7 @@ from pathlib import Path
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from a2a.types import Role, TextPart
+from codin.agent.types import Role, TextPart
 
 from codin.agent.base_agent import BaseAgent
 from codin.agent.code_planner import CodePlanner, CodePlannerConfig

--- a/src/codin/agent/__init__.py
+++ b/src/codin/agent/__init__.py
@@ -60,6 +60,13 @@ def get_code_agent():
     return CodeAgent
 
 
+def get_search_agent():
+    """Lazy import SearchAgent to avoid circular imports."""
+    from .search_agent import SearchAgent
+
+    return SearchAgent
+
+
 __all__ = [
     # Base agent interface
     'Agent',
@@ -96,5 +103,6 @@ __all__ = [
     'get_base_agent',
     'get_base_planner',
     'get_code_agent',
+    'get_search_agent',
 ]
 

--- a/src/codin/agent/code_agent.py
+++ b/src/codin/agent/code_agent.py
@@ -11,7 +11,7 @@ This module ports that control-flow to Python and wires it up with the rest of
 * :pymod:`codin.model` – LLM interfaces (OpenAI, Anthropic, Google, …)
 * :pymod:`codin.tool`  – execution of local sandbox + MCP tools
 * :pymod:`codin.sandbox` – pluggable execution back-ends
-* A2A protocol types from :pymod:`a2a.types`
+* Agent protocol types from :mod:`codin.agent.types`
 
 Implements the full iterative loop with tool calling, approvals, and events.
 """
@@ -27,8 +27,8 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-# Use a2a types directly
-from a2a.types import Role
+# Use protocol types directly
+from .types import Role
 from pydantic import BaseModel
 
 from ..agent.base import Agent, AgentRunInput, AgentRunOutput
@@ -50,20 +50,20 @@ from ..utils.message import (
 from .types import Message, TextPart
 
 __all__: list[str] = [
-    'AgentEvent',
-    'CodeAgent',
-    'ContinueDecision',
+    "AgentEvent",
+    "CodeAgent",
+    "ContinueDecision",
 ]
 
-logger = logging.getLogger('codin.agent.code_agent')
+logger = logging.getLogger("codin.agent.code_agent")
 
 
 class ContinueDecision(Enum):
     """Decision on whether to continue execution."""
 
-    CONTINUE = 'continue'
-    NEED_APPROVAL = 'need_approval'
-    CANCEL = 'cancel'
+    CONTINUE = "continue"
+    NEED_APPROVAL = "need_approval"
+    CANCEL = "cancel"
 
 
 class AgentEvent(BaseModel):
@@ -81,8 +81,8 @@ class CodeAgent(Agent):
     def __init__(
         self,
         *,
-        name: str = 'CodeAgent',
-        description: str = 'Python agent with sandbox + tools support and iterative execution',
+        name: str = "CodeAgent",
+        description: str = "Python agent with sandbox + tools support and iterative execution",
         llm_model: str | None = None,
         sandbox: Sandbox | None = None,
         tool_registry: ToolRegistry | None = None,
@@ -159,7 +159,7 @@ class CodeAgent(Agent):
         # Event callbacks
         self._event_callbacks: list[_t.Callable[[AgentEvent], _t.Awaitable[None]]] = []
 
-        logger.info(f'Initialized CodeAgent with {len(self.tool_registry.get_tools())} tools')
+        logger.info(f"Initialized CodeAgent with {len(self.tool_registry.get_tools())} tools")
 
     def add_event_callback(self, callback: _t.Callable[[AgentEvent], _t.Awaitable[None]]) -> None:
         """Add an event callback for monitoring agent execution."""
@@ -210,7 +210,7 @@ class CodeAgent(Agent):
             try:
                 await callback(event)
             except Exception as e:
-                logger.error(f'Error in event callback: {e}')
+                logger.error(f"Error in event callback: {e}")
 
     def _create_user_message(self, content: str, task_id: str | None = None) -> Message:
         """Create a user message for conversation history."""
@@ -220,7 +220,7 @@ class CodeAgent(Agent):
             parts=[TextPart(text=content)],
             contextId=self._context_id,
             taskId=task_id,
-            kind='message',
+            kind="message",
         )
 
     def _create_agent_message(self, content: str, task_id: str | None = None) -> Message:
@@ -231,7 +231,7 @@ class CodeAgent(Agent):
             parts=[TextPart(text=content)],
             contextId=self._context_id,
             taskId=task_id,
-            kind='message',
+            kind="message",
         )
 
     def _parse_tool_calls(self, content: str) -> list[ToolCall]:
@@ -248,11 +248,11 @@ class CodeAgent(Agent):
         tool_calls = []
 
         # Handle case where content is already a dict (from prompt_run response)
-        if isinstance(content, dict) and 'tool_calls' in content:
+        if isinstance(content, dict) and "tool_calls" in content:
             response_dict = content
         elif isinstance(content, str):
             # First try to parse as Python dict string (common format from LLM responses)
-            if content.strip().startswith('{') and 'tool_calls' in content:
+            if content.strip().startswith("{") and "tool_calls" in content:
                 try:
                     # First try JSON parsing
                     response_dict = json.loads(content)
@@ -268,17 +268,17 @@ class CodeAgent(Agent):
             response_dict = None
 
         if response_dict:
-            if 'tool_calls' in response_dict:
-                openai_tool_calls = response_dict['tool_calls']
+            if "tool_calls" in response_dict:
+                openai_tool_calls = response_dict["tool_calls"]
                 for call in openai_tool_calls:
                     if isinstance(call, dict):
                         # Handle both OpenAI format and Claude format
-                        if 'function' in call:
+                        if "function" in call:
                             # OpenAI format
-                            func = call['function']
-                            call_id = call.get('id', str(uuid.uuid4()))
-                            tool_name = func.get('name', '')
-                            arguments_str = func.get('arguments', '{}')
+                            func = call["function"]
+                            call_id = call.get("id", str(uuid.uuid4()))
+                            tool_name = func.get("name", "")
+                            arguments_str = func.get("arguments", "{}")
 
                             try:
                                 if isinstance(arguments_str, str):
@@ -287,13 +287,13 @@ class CodeAgent(Agent):
                                     arguments = arguments_str
                                 tool_calls.append(ToolCall(call_id=call_id, name=tool_name, arguments=arguments))
                             except json.JSONDecodeError:
-                                logger.error(f'Failed to parse tool arguments: {arguments_str}')
-                        elif 'type' in call and call['type'] == 'function':
+                                logger.error(f"Failed to parse tool arguments: {arguments_str}")
+                        elif "type" in call and call["type"] == "function":
                             # Claude format
-                            func = call.get('function', {})
-                            call_id = call.get('id', str(uuid.uuid4()))
-                            tool_name = func.get('name', '')
-                            arguments_str = func.get('arguments', '{}')
+                            func = call.get("function", {})
+                            call_id = call.get("id", str(uuid.uuid4()))
+                            tool_name = func.get("name", "")
+                            arguments_str = func.get("arguments", "{}")
 
                             try:
                                 if isinstance(arguments_str, str):
@@ -302,7 +302,7 @@ class CodeAgent(Agent):
                                     arguments = arguments_str
                                 tool_calls.append(ToolCall(call_id=call_id, name=tool_name, arguments=arguments))
                             except json.JSONDecodeError:
-                                logger.error(f'Failed to parse Claude tool arguments: {arguments_str}')
+                                logger.error(f"Failed to parse Claude tool arguments: {arguments_str}")
 
                 if tool_calls:
                     return tool_calls
@@ -311,7 +311,7 @@ class CodeAgent(Agent):
         # <function_calls>
         # [{"name": "tool_name", "arguments": {...}}, ...]
         # </function_calls>
-        multi_pattern = r'<function_calls>\s*(\[.*?\])\s*</function_calls>'
+        multi_pattern = r"<function_calls>\s*(\[.*?\])\s*</function_calls>"
         multi_matches = re.findall(multi_pattern, content, re.DOTALL)
 
         for match in multi_matches:
@@ -319,15 +319,15 @@ class CodeAgent(Agent):
                 calls_data = json.loads(match)
                 if isinstance(calls_data, list):
                     for call_data in calls_data:
-                        if isinstance(call_data, dict) and 'name' in call_data:
+                        if isinstance(call_data, dict) and "name" in call_data:
                             call_id = str(uuid.uuid4())
                             tool_calls.append(
                                 ToolCall(
-                                    call_id=call_id, name=call_data['name'], arguments=call_data.get('arguments', {})
+                                    call_id=call_id, name=call_data["name"], arguments=call_data.get("arguments", {})
                                 )
                             )
             except json.JSONDecodeError:
-                logger.error(f'Failed to parse multi-function calls: {match}')
+                logger.error(f"Failed to parse multi-function calls: {match}")
 
         # Pattern 2: Individual function call tags
         # <function_call name="tool_name">{"arg": "value"}</function_call>
@@ -340,7 +340,7 @@ class CodeAgent(Agent):
                 arguments = json.loads(args_str)
                 tool_calls.append(ToolCall(call_id=call_id, name=tool_name, arguments=arguments))
             except json.JSONDecodeError:
-                logger.error(f'Failed to parse arguments for tool {tool_name}: {args_str}')
+                logger.error(f"Failed to parse arguments for tool {tool_name}: {args_str}")
 
         # Pattern 3: Claude-style thinking with tool calls
         # Looking for patterns like:
@@ -361,7 +361,7 @@ class CodeAgent(Agent):
                     arguments = json.loads(args_str)
                     tool_calls.append(ToolCall(call_id=call_id, name=tool_name, arguments=arguments))
                 except json.JSONDecodeError:
-                    logger.error(f'Failed to parse thinking arguments for tool {tool_name}: {args_str}')
+                    logger.error(f"Failed to parse thinking arguments for tool {tool_name}: {args_str}")
 
         return tool_calls
 
@@ -392,16 +392,16 @@ class CodeAgent(Agent):
         """
         # Initialize default response structure
         parsed_response = {
-            'thinking': '',
-            'task_list': {'completed': [], 'pending': []},
-            'tool_calls': [],
-            'message': '',
-            'should_continue': True,
-            'raw_content': content,
+            "thinking": "",
+            "task_list": {"completed": [], "pending": []},
+            "tool_calls": [],
+            "message": "",
+            "should_continue": True,
+            "raw_content": content,
         }
 
         # Try to extract JSON from markdown code blocks first
-        json_pattern = r'```json\s*(\{.*?\})\s*```'
+        json_pattern = r"```json\s*(\{.*?\})\s*```"
         json_matches = re.findall(json_pattern, content, re.DOTALL)
 
         response_data = None
@@ -410,7 +410,7 @@ class CodeAgent(Agent):
             try:
                 response_data = json.loads(json_matches[0])
             except json.JSONDecodeError as e:
-                logger.warning(f'Failed to parse JSON from markdown block: {e}')
+                logger.warning(f"Failed to parse JSON from markdown block: {e}")
 
         # If no JSON block found, try parsing the entire content as JSON
         if not response_data:
@@ -418,40 +418,40 @@ class CodeAgent(Agent):
                 response_data = json.loads(content.strip())
             except json.JSONDecodeError:
                 # If JSON parsing fails, try to extract information from text
-                logger.debug('No valid JSON found, extracting from text content')
-                parsed_response['message'] = content
-                parsed_response['tool_calls'] = self._parse_tool_calls(content)
+                logger.debug("No valid JSON found, extracting from text content")
+                parsed_response["message"] = content
+                parsed_response["tool_calls"] = self._parse_tool_calls(content)
                 return parsed_response
 
         # Extract fields from parsed JSON
         if response_data and isinstance(response_data, dict):
-            parsed_response['thinking'] = response_data.get('thinking', '')
-            parsed_response['message'] = response_data.get('message', '')
-            parsed_response['should_continue'] = response_data.get('should_continue', True)
+            parsed_response["thinking"] = response_data.get("thinking", "")
+            parsed_response["message"] = response_data.get("message", "")
+            parsed_response["should_continue"] = response_data.get("should_continue", True)
 
             # Extract task list
-            task_list = response_data.get('task_list', {})
+            task_list = response_data.get("task_list", {})
             if isinstance(task_list, dict):
-                parsed_response['task_list']['completed'] = task_list.get('completed', [])
-                parsed_response['task_list']['pending'] = task_list.get('pending', [])
+                parsed_response["task_list"]["completed"] = task_list.get("completed", [])
+                parsed_response["task_list"]["pending"] = task_list.get("pending", [])
 
             # Extract tool calls and convert to ToolCall objects
-            tool_calls_data = response_data.get('tool_calls', [])
+            tool_calls_data = response_data.get("tool_calls", [])
             if isinstance(tool_calls_data, list):
                 for call_data in tool_calls_data:
-                    if isinstance(call_data, dict) and 'name' in call_data:
+                    if isinstance(call_data, dict) and "name" in call_data:
                         call_id = str(uuid.uuid4())
                         tool_call = ToolCall(
-                            call_id=call_id, name=call_data['name'], arguments=call_data.get('arguments', {})
+                            call_id=call_id, name=call_data["name"], arguments=call_data.get("arguments", {})
                         )
-                        parsed_response['tool_calls'].append(tool_call)
+                        parsed_response["tool_calls"].append(tool_call)
 
         return parsed_response
 
-    async def _execute_tool_call(self, tool_call: ToolCall, task_id: str = 'default') -> ToolCallResult:
+    async def _execute_tool_call(self, tool_call: ToolCall, task_id: str = "default") -> ToolCallResult:
         await self._emit_event(
-            'tool_call_start',
-            {'call_id': tool_call.call_id, 'tool_name': tool_call.name, 'arguments': tool_call.arguments},
+            "tool_call_start",
+            {"call_id": tool_call.call_id, "tool_name": tool_call.name, "arguments": tool_call.arguments},
         )
 
         try:
@@ -459,14 +459,14 @@ class CodeAgent(Agent):
             tool = self.tool_registry.get_tool(tool_call.name)
             if tool is None:
                 return ToolCallResult(
-                    call_id=tool_call.call_id, success=False, output='', error=f'Unknown tool: {tool_call.name}'
+                    call_id=tool_call.call_id, success=False, output="", error=f"Unknown tool: {tool_call.name}"
                 )
 
             # Check approval for potentially dangerous commands
             if await self._needs_approval(tool_call):
                 if not await self._request_approval(tool_call):
                     return ToolCallResult(
-                        call_id=tool_call.call_id, success=False, output='', error='Tool execution rejected by user'
+                        call_id=tool_call.call_id, success=False, output="", error="Tool execution rejected by user"
                     )
 
             # Execute the tool
@@ -474,15 +474,15 @@ class CodeAgent(Agent):
 
             result = await self.tool_executor.execute(tool_call.name, tool_call.arguments, tool_context)
 
-            output = str(result) if result is not None else ''
+            output = str(result) if result is not None else ""
 
             await self._emit_event(
-                'tool_call_end',
+                "tool_call_end",
                 {
-                    'call_id': tool_call.call_id,
-                    'tool_name': tool_call.name,
-                    'success': True,
-                    'output': output,  # No truncation - show full output
+                    "call_id": tool_call.call_id,
+                    "tool_name": tool_call.name,
+                    "success": True,
+                    "output": output,  # No truncation - show full output
                 },
             )
 
@@ -493,15 +493,15 @@ class CodeAgent(Agent):
             )
 
         except Exception as e:
-            error_msg = f'Tool execution error: {e!s}'
-            logger.error(f'Error executing tool {tool_call.name}: {e}', exc_info=True)
+            error_msg = f"Tool execution error: {e!s}"
+            logger.error(f"Error executing tool {tool_call.name}: {e}", exc_info=True)
 
             await self._emit_event(
-                'tool_call_end',
-                {'call_id': tool_call.call_id, 'tool_name': tool_call.name, 'success': False, 'error': error_msg},
+                "tool_call_end",
+                {"call_id": tool_call.call_id, "tool_name": tool_call.name, "success": False, "error": error_msg},
             )
 
-            return ToolCallResult(call_id=tool_call.call_id, success=False, output='', error=error_msg)
+            return ToolCallResult(call_id=tool_call.call_id, success=False, output="", error=error_msg)
 
     async def _needs_approval(self, tool_call: ToolCall) -> bool:
         """Check if a tool call needs user approval."""
@@ -511,11 +511,11 @@ class CodeAgent(Agent):
             return True
         # UNSAFE_ONLY
         # Check if this is a potentially unsafe operation
-        dangerous_tools = {'shell', 'container_exec', 'file_write', 'exec'}
+        dangerous_tools = {"shell", "container_exec", "file_write", "exec"}
         if tool_call.name in dangerous_tools:
             # Check if command was already approved
-            if tool_call.name == 'shell' or tool_call.name == 'container_exec':
-                command = tool_call.arguments.get('command', [])
+            if tool_call.name == "shell" or tool_call.name == "container_exec":
+                command = tool_call.arguments.get("command", [])
                 if isinstance(command, str):
                     command = [command]
                 command_tuple = tuple(command)
@@ -527,22 +527,22 @@ class CodeAgent(Agent):
         """Request user approval for a tool call."""
         # In a real implementation, this would show a UI prompt
         # For now, we'll auto-approve to keep the demo working
-        logger.info(f'Auto-approving tool call: {tool_call.name} with args {tool_call.arguments}')
+        logger.info(f"Auto-approving tool call: {tool_call.name} with args {tool_call.arguments}")
 
         # Remember this approval
-        if tool_call.name in {'shell', 'container_exec'}:
-            command = tool_call.arguments.get('command', [])
+        if tool_call.name in {"shell", "container_exec"}:
+            command = tool_call.arguments.get("command", [])
             if isinstance(command, str):
                 command = [command]
             self._approved_commands.add(tuple(command))
 
         await self._emit_event(
-            'approval_requested',
+            "approval_requested",
             {
-                'call_id': tool_call.call_id,
-                'tool_name': tool_call.name,
-                'arguments': tool_call.arguments,
-                'auto_approved': True,
+                "call_id": tool_call.call_id,
+                "tool_name": tool_call.name,
+                "arguments": tool_call.arguments,
+                "auto_approved": True,
             },
         )
 
@@ -554,13 +554,13 @@ class CodeAgent(Agent):
         """Run a single turn of the conversation using prompt_run."""
         self._turn_count += 1
 
-        await self._emit_event('turn_start', {'turn': self._turn_count, 'input_messages': len(turn_input)})
+        await self._emit_event("turn_start", {"turn": self._turn_count, "input_messages": len(turn_input)})
 
         try:
             # Get pre-converted tool definitions from run_context and convert to dict format
-            tool_definitions_objects = run_context.get('tool_definitions', [])
+            tool_definitions_objects = run_context.get("tool_definitions", [])
             tool_definitions = [
-                {'name': td.name, 'description': td.description, 'parameters': self._clean_parameters(td.parameters)}
+                {"name": td.name, "description": td.description, "parameters": self._clean_parameters(td.parameters)}
                 for td in tool_definitions_objects
             ]
 
@@ -569,84 +569,84 @@ class CodeAgent(Agent):
             for msg in turn_input[:-1]:  # All but the last message
                 history_messages.append(
                     {
-                        'role': 'user' if msg.role == Role.user else 'assistant',
-                        'content': extract_text_from_message(msg),
+                        "role": "user" if msg.role == Role.user else "assistant",
+                        "content": extract_text_from_message(msg),
                     }
                 )
 
             # Get the current user input
-            current_input = extract_text_from_message(turn_input[-1]) if turn_input else ''
+            current_input = extract_text_from_message(turn_input[-1]) if turn_input else ""
 
             # Format tool results from previous turn if any
-            tool_results_text = ''
-            if hasattr(self, '_last_tool_results') and self._last_tool_results:
+            tool_results_text = ""
+            if hasattr(self, "_last_tool_results") and self._last_tool_results:
                 tool_results_text = format_tool_results_for_conversation(self._last_tool_results)
 
             # Get task_id and task_list from run_context
-            task_id = run_context.get('task_id', 'default')
-            task_list = run_context.get('task_list', {'completed': [], 'pending': []})
+            task_id = run_context.get("task_id", "default")
+            task_list = run_context.get("task_list", {"completed": [], "pending": []})
 
             # Prepare variables for prompt_run with task list support
             variables = {
-                'agent_name': self.name,
-                'task_id': task_id,
-                'turn_count': self._turn_count,
-                'has_tools': len(tool_definitions) > 0,
-                'tools': tool_definitions,
-                'has_history': len(history_messages) > 0,
-                'history_text': format_history_for_prompt(history_messages),
-                'user_input': current_input if current_input else None,
-                'tool_results': bool(tool_results_text),
-                'tool_results_text': tool_results_text,
-                'task_list': task_list,  # Use task_list from run_context
-                'rules': self.rules,
+                "agent_name": self.name,
+                "task_id": task_id,
+                "turn_count": self._turn_count,
+                "has_tools": len(tool_definitions) > 0,
+                "tools": tool_definitions,
+                "has_history": len(history_messages) > 0,
+                "history_text": format_history_for_prompt(history_messages),
+                "user_input": current_input if current_input else None,
+                "tool_results": bool(tool_results_text),
+                "tool_results_text": tool_results_text,
+                "task_list": task_list,  # Use task_list from run_context
+                "rules": self.rules,
             }
 
-            logger.debug('RunTurn, task_id: %s, turn: %s, variables: %s', task_id, self._turn_count, variables)
+            logger.debug("RunTurn, task_id: %s, turn: %s, variables: %s", task_id, self._turn_count, variables)
 
             # Debug mode: Print detailed information about what's being sent to LLM
             if self.debug:
-                print('\n' + '=' * 80)
-                print(f'🐛 DEBUG MODE - Turn {self._turn_count}')
-                print('=' * 80)
-                print('📝 Variables being sent to LLM:')
+                print("\n" + "=" * 80)
+                print(f"🐛 DEBUG MODE - Turn {self._turn_count}")
+                print("=" * 80)
+                print("📝 Variables being sent to LLM:")
                 for key, value in variables.items():
-                    if key == 'tools':
-                        print(f'  {key}: [{len(value)} tools] {[tool.get("name", "unknown") for tool in value]}')
-                    elif key == 'history_text':
-                        print(f'  {key}: {len(str(value))} characters')
+                    if key == "tools":
+                        print(f"  {key}: [{len(value)} tools] {[tool.get('name', 'unknown') for tool in value]}")
+                    elif key == "history_text":
+                        print(f"  {key}: {len(str(value))} characters")
                         if value:
-                            print(f'    Preview: {str(value)[:200]}...')
-                    elif key == 'user_input':
-                        print(f'  {key}: {value!r}')
-                    elif key == 'tool_results_text':
+                            print(f"    Preview: {str(value)[:200]}...")
+                    elif key == "user_input":
+                        print(f"  {key}: {value!r}")
+                    elif key == "tool_results_text":
                         if value:
-                            print(f'  {key}: {len(str(value))} characters')
-                            print(f'    Preview: {str(value)[:200]}...')
+                            print(f"  {key}: {len(str(value))} characters")
+                            print(f"    Preview: {str(value)[:200]}...")
                         else:
-                            print(f'  {key}: None')
+                            print(f"  {key}: None")
                     else:
-                        print(f'  {key}: {value!r}')
+                        print(f"  {key}: {value!r}")
 
-                print('\n🔧 Available Tools:')
+                print("\n🔧 Available Tools:")
                 for i, tool_def in enumerate(tool_definitions):
                     print(
-                        f'  {i + 1}. {tool_def.get("name", "unknown")}: {tool_def.get("description", "no description")}'
+                        f"  {i + 1}. {tool_def.get('name', 'unknown')}: {tool_def.get('description', 'no description')}"
                     )
 
-                print('\n📊 Context Summary:')
-                print(f'  - Turn: {self._turn_count}/{self.max_turns}')
-                print(f'  - Has previous results: {bool(tool_results_text)}')
-                print(f'  - Has conversation history: {len(history_messages) > 0}')
-                print(f'  - Current user input: {bool(current_input)}')
-                print(f'  - Task ID: {task_id}')
-                print('=' * 80 + '\n')
+                print("\n📊 Context Summary:")
+                print(f"  - Turn: {self._turn_count}/{self.max_turns}")
+                print(f"  - Has previous results: {bool(tool_results_text)}")
+                print(f"  - Has conversation history: {len(history_messages) > 0}")
+                print(f"  - Current user input: {bool(current_input)}")
+                print(f"  - Task ID: {task_id}")
+                print("=" * 80 + "\n")
 
             # Use prompt_run to get LLM response with timeout handling
             try:
                 response = await asyncio.wait_for(
                     prompt_run(
-                        'code_agent_loop',
+                        "code_agent_loop",
                         variables=variables,
                         tools=tool_definitions,  # Also pass to prompt_run for function calling
                         stream=False,  # Disable streaming for now to get complete response
@@ -654,44 +654,44 @@ class CodeAgent(Agent):
                     timeout=120.0,  # 2 minute timeout
                 )
             except TimeoutError:
-                logger.error('LLM request timed out after 2 minutes')
+                logger.error("LLM request timed out after 2 minutes")
                 error_message = self._create_agent_message(
                     "I'm sorry, but my request to the language model timed out. This might be due to "
-                    'network issues or high server load. Please try again.',
+                    "network issues or high server load. Please try again.",
                     task_id,
                 )
                 return [error_message], []
             except Exception as e:
-                logger.error(f'LLM request failed: {e}')
+                logger.error(f"LLM request failed: {e}")
                 # Try to provide a helpful fallback response
-                if 'list tools' in current_input.lower():
+                if "list tools" in current_input.lower():
                     # Special case for tool listing
                     tools_list = []
                     for tool in self.tool_registry.get_tools():
-                        tools_list.append(f'- {tool.name}: {tool.description}')
+                        tools_list.append(f"- {tool.name}: {tool.description}")
 
-                    fallback_content = f'I have access to {len(self.tool_registry.get_tools())} tools:\n\n' + '\n'.join(
+                    fallback_content = f"I have access to {len(self.tool_registry.get_tools())} tools:\n\n" + "\n".join(
                         tools_list
                     )
                     fallback_message = self._create_agent_message(fallback_content, task_id)
                     return [fallback_message], []
                 error_message = self._create_agent_message(
-                    f'I encountered an error while processing your request: {e!s}. '
-                    f'Please try rephrasing your request or try again later.',
+                    f"I encountered an error while processing your request: {e!s}. "
+                    f"Please try rephrasing your request or try again later.",
                     task_id,
                 )
                 return [error_message], []
 
             # Extract content from response
-            content = ''
-            if hasattr(response, 'message') and response.message:
+            content = ""
+            if hasattr(response, "message") and response.message:
                 # Extract text from A2A message parts
                 for part in response.message.parts:
-                    if hasattr(part, 'root') and hasattr(part.root, 'text'):
+                    if hasattr(part, "root") and hasattr(part.root, "text"):
                         content += part.root.text
-                    elif hasattr(part, 'text'):
+                    elif hasattr(part, "text"):
                         content += part.text
-            elif hasattr(response, 'content'):
+            elif hasattr(response, "content"):
                 if asyncio.iscoroutine(response.content):
                     content = str(await response.content)
                 else:
@@ -705,70 +705,70 @@ class CodeAgent(Agent):
             # Emit debug event with comprehensive debug information
             if self.debug:
                 debug_info = {
-                    'turn_count': self._turn_count,
-                    'raw_content_length': len(content),
-                    'thinking': parsed_response['thinking'],
-                    'message': parsed_response['message'],
-                    'should_continue': parsed_response['should_continue'],
-                    'task_list': {
-                        'completed_count': len(parsed_response['task_list']['completed']),
-                        'pending_count': len(parsed_response['task_list']['pending']),
-                        'completed': parsed_response['task_list']['completed'],
-                        'pending': parsed_response['task_list']['pending'],
+                    "turn_count": self._turn_count,
+                    "raw_content_length": len(content),
+                    "thinking": parsed_response["thinking"],
+                    "message": parsed_response["message"],
+                    "should_continue": parsed_response["should_continue"],
+                    "task_list": {
+                        "completed_count": len(parsed_response["task_list"]["completed"]),
+                        "pending_count": len(parsed_response["task_list"]["pending"]),
+                        "completed": parsed_response["task_list"]["completed"],
+                        "pending": parsed_response["task_list"]["pending"],
                     },
-                    'tool_calls': [],
+                    "tool_calls": [],
                 }
 
-                if parsed_response['tool_calls']:
-                    debug_info['tool_calls'] = [
+                if parsed_response["tool_calls"]:
+                    debug_info["tool_calls"] = [
                         {
-                            'name': tool_call.name,
-                            'arguments_keys': list(tool_call.arguments.keys()),
-                            'call_id': tool_call.call_id,
+                            "name": tool_call.name,
+                            "arguments_keys": list(tool_call.arguments.keys()),
+                            "call_id": tool_call.call_id,
                         }
-                        for tool_call in parsed_response['tool_calls']
+                        for tool_call in parsed_response["tool_calls"]
                     ]
 
-                await self._emit_event('debug_llm_response', debug_info)
+                await self._emit_event("debug_llm_response", debug_info)
 
             # Update task list in run_context from response
-            if parsed_response['task_list']['completed'] or parsed_response['task_list']['pending']:
-                run_context['task_list'] = parsed_response['task_list']
+            if parsed_response["task_list"]["completed"] or parsed_response["task_list"]["pending"]:
+                run_context["task_list"] = parsed_response["task_list"]
                 logger.info(
-                    f'Updated task list: completed={len(parsed_response["task_list"]["completed"])}, '
-                    f'pending={len(parsed_response["task_list"]["pending"])}'
+                    f"Updated task list: completed={len(parsed_response['task_list']['completed'])}, "
+                    f"pending={len(parsed_response['task_list']['pending'])}"
                 )
 
             # Emit the LLM response with structured data
             await self._emit_event(
-                'llm_response',
+                "llm_response",
                 {
-                    'content': content,
-                    'thinking': parsed_response['thinking'],
-                    'message': parsed_response['message'],
-                    'task_list': parsed_response['task_list'],
-                    'should_continue': parsed_response['should_continue'],
-                    'has_tool_calls': len(parsed_response['tool_calls']) > 0,
+                    "content": content,
+                    "thinking": parsed_response["thinking"],
+                    "message": parsed_response["message"],
+                    "task_list": parsed_response["task_list"],
+                    "should_continue": parsed_response["should_continue"],
+                    "has_tool_calls": len(parsed_response["tool_calls"]) > 0,
                 },
             )
 
             # Get tool calls from parsed response
-            tool_calls = parsed_response['tool_calls']
+            tool_calls = parsed_response["tool_calls"]
 
             # Execute tool calls if any
             tool_results = []
             if tool_calls:
-                await self._emit_event('tool_results_start', {'num_tools': len(tool_calls)})
+                await self._emit_event("tool_results_start", {"num_tools": len(tool_calls)})
 
                 for tool_call in tool_calls:
                     try:
                         # Emit tool call start event
                         await self._emit_event(
-                            'tool_call_start',
+                            "tool_call_start",
                             {
-                                'tool_name': tool_call.name,
-                                'arguments': tool_call.arguments,
-                                'call_id': tool_call.call_id,
+                                "tool_name": tool_call.name,
+                                "arguments": tool_call.arguments,
+                                "call_id": tool_call.call_id,
                             },
                         )
 
@@ -781,59 +781,59 @@ class CodeAgent(Agent):
 
                         # Emit tool call end event
                         await self._emit_event(
-                            'tool_call_end',
+                            "tool_call_end",
                             {
-                                'tool_name': tool_call.name,
-                                'call_id': tool_call.call_id,
-                                'success': result.success,
-                                'output': result.output,
-                                'error': result.error,
+                                "tool_name": tool_call.name,
+                                "call_id": tool_call.call_id,
+                                "success": result.success,
+                                "output": result.output,
+                                "error": result.error,
                             },
                         )
 
                     except TimeoutError:
-                        logger.error(f'Tool call {tool_call.name} timed out after 1 minute')
+                        logger.error(f"Tool call {tool_call.name} timed out after 1 minute")
                         error_result = ToolCallResult(
                             call_id=tool_call.call_id,
                             success=False,
-                            output='',
-                            error='Tool execution timed out after 1 minute',
+                            output="",
+                            error="Tool execution timed out after 1 minute",
                         )
                         tool_results.append(error_result)
 
                         await self._emit_event(
-                            'tool_call_end',
+                            "tool_call_end",
                             {
-                                'tool_name': tool_call.name,
-                                'call_id': tool_call.call_id,
-                                'success': False,
-                                'output': '',
-                                'error': 'Tool execution timed out',
+                                "tool_name": tool_call.name,
+                                "call_id": tool_call.call_id,
+                                "success": False,
+                                "output": "",
+                                "error": "Tool execution timed out",
                             },
                         )
 
                     except Exception as e:
-                        logger.error(f'Error executing tool call {tool_call.name}: {e}')
-                        error_result = ToolCallResult(call_id=tool_call.call_id, success=False, output='', error=str(e))
+                        logger.error(f"Error executing tool call {tool_call.name}: {e}")
+                        error_result = ToolCallResult(call_id=tool_call.call_id, success=False, output="", error=str(e))
                         tool_results.append(error_result)
 
                         await self._emit_event(
-                            'tool_call_end',
+                            "tool_call_end",
                             {
-                                'tool_name': tool_call.name,
-                                'call_id': tool_call.call_id,
-                                'success': False,
-                                'output': '',
-                                'error': str(e),
+                                "tool_name": tool_call.name,
+                                "call_id": tool_call.call_id,
+                                "success": False,
+                                "output": "",
+                                "error": str(e),
                             },
                         )
 
                 await self._emit_event(
-                    'tool_results',
+                    "tool_results",
                     {
-                        'num_tools_executed': len(tool_results),
-                        'successful_calls': sum(1 for r in tool_results if r.success),
-                        'failed_calls': sum(1 for r in tool_results if not r.success),
+                        "num_tools_executed": len(tool_results),
+                        "successful_calls": sum(1 for r in tool_results if r.success),
+                        "failed_calls": sum(1 for r in tool_results if not r.success),
                     },
                 )
 
@@ -841,28 +841,28 @@ class CodeAgent(Agent):
             self._last_tool_results = tool_results
 
             # Create response message using the structured message field
-            response_message_content = parsed_response['message'] or content
+            response_message_content = parsed_response["message"] or content
             response_message = self._create_agent_message(response_message_content, task_id)
 
             # Store the should_continue flag for task completion checking
-            run_context['should_continue'] = parsed_response['should_continue']
+            run_context["should_continue"] = parsed_response["should_continue"]
 
             # Add tool results to conversation if any
             if tool_results:
                 # Create a tool results message
                 tool_results_text = format_tool_results_for_conversation(tool_results)
                 tool_results_message = self._create_agent_message(
-                    f'Tool execution results:\n{tool_results_text}', task_id
+                    f"Tool execution results:\n{tool_results_text}", task_id
                 )
                 return [response_message, tool_results_message], tool_results
             return [response_message], tool_results
 
         except Exception as e:
-            logger.error(f'Error in turn execution: {e}')
-            await self._emit_event('turn_error', {'error': str(e), 'turn': self._turn_count})
+            logger.error(f"Error in turn execution: {e}")
+            await self._emit_event("turn_error", {"error": str(e), "turn": self._turn_count})
 
             # Create error response
-            error_message = self._create_agent_message(f'I encountered an error: {e!s}', task_id)
+            error_message = self._create_agent_message(f"I encountered an error: {e!s}", task_id)
             return [error_message], []
 
     def _parse_json_tool_calls(self, content: str) -> list[ToolCall]:
@@ -873,30 +873,29 @@ class CodeAgent(Agent):
             # Look for JSON blocks in the content
             import re
 
-            json_pattern = r'```json\s*(\{.*?\})\s*```'
+            json_pattern = r"```json\s*(\{.*?\})\s*```"
             matches = re.findall(json_pattern, content, re.DOTALL)
 
             for match in matches:
                 try:
                     data = json.loads(match)
-                    if 'tool_calls' in data and isinstance(data['tool_calls'], list):
-                        for tc_data in data['tool_calls']:
-                            if isinstance(tc_data, dict) and 'name' in tc_data:
+                    if "tool_calls" in data and isinstance(data["tool_calls"], list):
+                        for tc_data in data["tool_calls"]:
+                            if isinstance(tc_data, dict) and "name" in tc_data:
                                 tool_call = ToolCall(
                                     call_id=str(uuid.uuid4()),
-                                    name=tc_data['name'],
-                                    arguments=tc_data.get('arguments', {}),
+                                    name=tc_data["name"],
+                                    arguments=tc_data.get("arguments", {}),
                                 )
                                 tool_calls.append(tool_call)
                 except json.JSONDecodeError as e:
-                    logger.warning(f'Failed to parse JSON tool call: {e}')
+                    logger.warning(f"Failed to parse JSON tool call: {e}")
                     continue
 
         except Exception as e:
-            logger.warning(f'Error parsing tool calls from content: {e}')
+            logger.warning(f"Error parsing tool calls from content: {e}")
 
         return tool_calls
-
 
     async def run(self, input_data: AgentRunInput) -> AgentRunOutput:
         """Run the agent with iterative execution until task completion."""
@@ -908,10 +907,10 @@ class CodeAgent(Agent):
 
         # Initialize run context with task-specific data
         run_context = {
-            'task_id': task_id,
-            'task_list': {'completed': [], 'pending': []},
-            'tool_definitions': tool_definitions,
-            'should_continue': True,
+            "task_id": task_id,
+            "task_list": {"completed": [], "pending": []},
+            "tool_definitions": tool_definitions,
+            "should_continue": True,
         }
 
         # Initialize conversation with user input
@@ -923,13 +922,13 @@ class CodeAgent(Agent):
         iteration = 0
 
         await self._emit_event(
-            'task_start',
+            "task_start",
             {
-                'task_id': task_id,
-                'session_id': self._context_id,
-                'iteration': 0,
-                'elapsed_time': 0.0,
-                'user_input': extract_text_from_message(input_data.message),
+                "task_id": task_id,
+                "session_id": self._context_id,
+                "iteration": 0,
+                "elapsed_time": 0.0,
+                "user_input": extract_text_from_message(input_data.message),
             },
         )
 
@@ -943,7 +942,7 @@ class CodeAgent(Agent):
                 continue_decision = self._should_continue_execution(iteration, elapsed_time, total_tool_calls)
 
                 if continue_decision != ContinueDecision.CONTINUE:
-                    logger.info(f'Stopping execution: {continue_decision.value}')
+                    logger.info(f"Stopping execution: {continue_decision.value}")
                     break
 
                 # Run a single turn
@@ -957,14 +956,14 @@ class CodeAgent(Agent):
 
                 # Check if the task is complete
                 if self._is_task_complete(response_messages, tool_results, run_context):
-                    logger.info('Task completed successfully')
+                    logger.info("Task completed successfully")
                     await self._emit_event(
-                        'task_complete',
+                        "task_complete",
                         {
-                            'task_id': task_id,
-                            'iterations': iteration,
-                            'total_tool_calls': total_tool_calls,
-                            'elapsed_time': elapsed_time,
+                            "task_id": task_id,
+                            "iterations": iteration,
+                            "total_tool_calls": total_tool_calls,
+                            "elapsed_time": elapsed_time,
                         },
                     )
                     break
@@ -974,24 +973,24 @@ class CodeAgent(Agent):
                     # Add tool results to conversation and continue
                     continue
                 # No tool calls, task is likely complete
-                logger.info('No tool calls in response, task appears complete')
+                logger.info("No tool calls in response, task appears complete")
                 await self._emit_event(
-                    'task_complete',
+                    "task_complete",
                     {
-                        'task_id': task_id,
-                        'iterations': iteration,
-                        'total_tool_calls': total_tool_calls,
-                        'elapsed_time': elapsed_time,
+                        "task_id": task_id,
+                        "iterations": iteration,
+                        "total_tool_calls": total_tool_calls,
+                        "elapsed_time": elapsed_time,
                     },
                 )
                 break
 
             # If we hit max iterations
             if iteration >= max_iterations:
-                logger.warning(f'Reached maximum iterations ({max_iterations})')
+                logger.warning(f"Reached maximum iterations ({max_iterations})")
                 await self._emit_event(
-                    'task_timeout',
-                    {'task_id': task_id, 'max_iterations': max_iterations, 'total_tool_calls': total_tool_calls},
+                    "task_timeout",
+                    {"task_id": task_id, "max_iterations": max_iterations, "total_tool_calls": total_tool_calls},
                 )
 
             # Get the final response (last assistant message)
@@ -1003,7 +1002,7 @@ class CodeAgent(Agent):
 
             if not final_response:
                 # Create a default response if none found
-                final_response = self._create_agent_message('Task completed.', task_id)
+                final_response = self._create_agent_message("Task completed.", task_id)
 
             # Store conversation in memory
             if self.memory_system:
@@ -1011,52 +1010,52 @@ class CodeAgent(Agent):
                     for msg in conversation_history:
                         await self.memory_system.add_message(msg)
                 except Exception as e:
-                    logger.warning(f'Failed to store conversation in memory: {e}')
+                    logger.warning(f"Failed to store conversation in memory: {e}")
 
             await self._emit_event(
-                'task_end',
+                "task_end",
                 {
-                    'task_id': task_id,
-                    'session_id': self._context_id,
-                    'iteration': iteration,
-                    'elapsed_time': time.time() - self._start_time,
+                    "task_id": task_id,
+                    "session_id": self._context_id,
+                    "iteration": iteration,
+                    "elapsed_time": time.time() - self._start_time,
                 },
             )
 
             return AgentRunOutput(
                 result=final_response,
                 metadata={
-                    'task_id': task_id,
-                    'iterations': iteration,
-                    'total_tool_calls': total_tool_calls,
-                    'elapsed_time': time.time() - self._start_time,
-                    'conversation_length': len(conversation_history),
+                    "task_id": task_id,
+                    "iterations": iteration,
+                    "total_tool_calls": total_tool_calls,
+                    "elapsed_time": time.time() - self._start_time,
+                    "conversation_length": len(conversation_history),
                 },
             )
 
         except Exception as e:
-            logger.error(f'Error in agent execution: {e}', exc_info=True)
-            await self._emit_event('task_error', {'task_id': task_id, 'error': str(e), 'iteration': iteration})
+            logger.error(f"Error in agent execution: {e}", exc_info=True)
+            await self._emit_event("task_error", {"task_id": task_id, "error": str(e), "iteration": iteration})
 
             # Return error response
-            error_response = self._create_agent_message(f'I encountered an error: {e!s}', task_id)
+            error_response = self._create_agent_message(f"I encountered an error: {e!s}", task_id)
             await self._emit_event(
-                'task_end',
+                "task_end",
                 {
-                    'task_id': task_id,
-                    'session_id': self._context_id,
-                    'iteration': iteration,
-                    'elapsed_time': time.time() - self._start_time,
+                    "task_id": task_id,
+                    "session_id": self._context_id,
+                    "iteration": iteration,
+                    "elapsed_time": time.time() - self._start_time,
                 },
             )
             return AgentRunOutput(
                 result=error_response,
                 metadata={
-                    'task_id': task_id,
-                    'error': str(e),
-                    'iterations': iteration,
-                    'total_tool_calls': total_tool_calls,
-                    'elapsed_time': time.time() - self._start_time,
+                    "task_id": task_id,
+                    "error": str(e),
+                    "iterations": iteration,
+                    "total_tool_calls": total_tool_calls,
+                    "elapsed_time": time.time() - self._start_time,
                 },
             )
 
@@ -1065,10 +1064,10 @@ class CodeAgent(Agent):
     ) -> bool:
         """Determine if the task is complete based on the response."""
         # Check if we have the should_continue flag from the structured response
-        if 'should_continue' in run_context:
+        if "should_continue" in run_context:
             # Use the explicit should_continue flag from the LLM response
-            task_complete = not run_context['should_continue']
-            logger.info(f'Task completion based on should_continue flag: {task_complete}')
+            task_complete = not run_context["should_continue"]
+            logger.info(f"Task completion based on should_continue flag: {task_complete}")
             return task_complete
 
         # Fallback to original logic if no should_continue field found
@@ -1080,28 +1079,28 @@ class CodeAgent(Agent):
 
                 # Look for completion indicators
                 completion_indicators = [
-                    'task completed',
-                    'finished',
-                    'done',
-                    'complete',
-                    'successfully created',
-                    'successfully executed',
-                    'no further',
+                    "task completed",
+                    "finished",
+                    "done",
+                    "complete",
+                    "successfully created",
+                    "successfully executed",
+                    "no further",
                     "that's all",
-                    'task is complete',
+                    "task is complete",
                 ]
 
                 # Look for continuation indicators
                 continuation_indicators = [
-                    'let me',
+                    "let me",
                     "i'll",
-                    'next i',
-                    'now i',
-                    'first i',
-                    'tool_calls',
-                    'need to',
-                    'should',
-                    'will',
+                    "next i",
+                    "now i",
+                    "first i",
+                    "tool_calls",
+                    "need to",
+                    "should",
+                    "will",
                 ]
 
                 has_completion = any(indicator in last_message_text for indicator in completion_indicators)
@@ -1112,7 +1111,7 @@ class CodeAgent(Agent):
                     return True
 
                 # If it has no continuation indicators and no tool calls, likely complete
-                if not has_continuation and 'tool_calls' not in last_message_text:
+                if not has_continuation and "tool_calls" not in last_message_text:
                     return True
 
         return False
@@ -1125,9 +1124,9 @@ class CodeAgent(Agent):
         self._completed_actions.clear()
         self._last_tool_calls.clear()
 
-        await self._emit_event('conversation_reset', {'new_context_id': self._context_id})
+        await self._emit_event("conversation_reset", {"new_context_id": self._context_id})
 
-        logger.info('Conversation history reset')
+        logger.info("Conversation history reset")
 
     async def get_memory_history(self, limit: int = 50, query: str | None = None) -> list[Message]:
         """Get conversation history from memory system with optional search.
@@ -1159,18 +1158,18 @@ class CodeAgent(Agent):
                 # Use conversation_summary template
                 from ..prompt import prompt_run
 
-                response = await prompt_run('conversation_summary', variables={'conversation_text': text})
+                response = await prompt_run("conversation_summary", variables={"conversation_text": text})
 
                 # Extract content from response
-                content = ''
-                if hasattr(response, 'message') and response.message:
+                content = ""
+                if hasattr(response, "message") and response.message:
                     # Extract text from A2A message parts
                     for part in response.message.parts:
-                        if hasattr(part, 'root') and hasattr(part.root, 'text'):
+                        if hasattr(part, "root") and hasattr(part.root, "text"):
                             content += part.root.text
-                        elif hasattr(part, 'text'):
+                        elif hasattr(part, "text"):
                             content += part.text
-                elif hasattr(response, 'content'):
+                elif hasattr(response, "content"):
                     content = str(response.content)
                 else:
                     content = str(response)
@@ -1183,20 +1182,20 @@ class CodeAgent(Agent):
                 except json.JSONDecodeError:
                     # Fallback if LLM doesn't return valid JSON
                     return {
-                        'summary': content,  # Full content, no truncation
-                        'entities': {},
-                        'id_mappings': {},
+                        "summary": content,  # Full content, no truncation
+                        "entities": {},
+                        "id_mappings": {},
                     }
             except Exception:
                 # Fallback to simple summary
                 return {
-                    'summary': text,  # Full text, no truncation
-                    'entities': {},
-                    'id_mappings': {},
+                    "summary": text,  # Full text, no truncation
+                    "entities": {},
+                    "id_mappings": {},
                 }
 
         # Use memory system's compression with LLM summarizer
-        if hasattr(self.memory_system, 'compress_old_messages'):
+        if hasattr(self.memory_system, "compress_old_messages"):
             return await self.memory_system.compress_old_messages(
                 self._context_id, keep_recent, chunk_size, llm_summarizer
             )
@@ -1205,57 +1204,57 @@ class CodeAgent(Agent):
     def get_conversation_summary(self) -> dict[str, _t.Any]:
         """Get a summary of the current conversation state."""
         return {
-            'context_id': self._context_id,
-            'message_count': len(self._conversation_history),
-            'user_messages': len([msg for msg in self._conversation_history if msg.role == Role.user]),
-            'agent_messages': len([msg for msg in self._conversation_history if msg.role == Role.agent]),
-            'approved_commands': len(self._approved_commands),
-            'last_activity': (
-                self._conversation_history[-1].metadata.get('timestamp') if self._conversation_history else None
+            "context_id": self._context_id,
+            "message_count": len(self._conversation_history),
+            "user_messages": len([msg for msg in self._conversation_history if msg.role == Role.user]),
+            "agent_messages": len([msg for msg in self._conversation_history if msg.role == Role.agent]),
+            "approved_commands": len(self._approved_commands),
+            "last_activity": (
+                self._conversation_history[-1].metadata.get("timestamp") if self._conversation_history else None
             ),
         }
 
     def add_tool(self, tool) -> None:
         """Add a tool or toolset to the agent."""
-        if hasattr(tool, 'tools'):  # It's a toolset
+        if hasattr(tool, "tools"):  # It's a toolset
             self.tool_registry.register_toolset(tool)
         else:  # It's a single tool
             self.tool_registry.register_tool(tool)
 
     async def cleanup(self) -> None:
         """Cleanup the agent and all its resources."""
-        logger.debug('Cleaning up CodeAgent resources...')
+        logger.debug("Cleaning up CodeAgent resources...")
 
         # Cleanup all toolsets
         for toolset in self.tool_registry.get_toolsets():
             try:
-                if hasattr(toolset, 'cleanup'):
+                if hasattr(toolset, "cleanup"):
                     await toolset.cleanup()
-                elif hasattr(toolset, 'close'):
+                elif hasattr(toolset, "close"):
                     await toolset.close()
-                logger.debug(f'Cleaned up toolset: {toolset.name}')
+                logger.debug(f"Cleaned up toolset: {toolset.name}")
             except Exception as e:
-                logger.warning(f'Error cleaning up toolset {toolset.name}: {e}')
+                logger.warning(f"Error cleaning up toolset {toolset.name}: {e}")
 
         # Cleanup individual tools
         for tool in self.tool_registry.get_tools():
             try:
-                if hasattr(tool, 'cleanup'):
+                if hasattr(tool, "cleanup"):
                     await tool.cleanup()
-                elif hasattr(tool, 'close'):
+                elif hasattr(tool, "close"):
                     await tool.close()
             except Exception as e:
-                logger.warning(f'Error cleaning up tool {tool.name}: {e}')
+                logger.warning(f"Error cleaning up tool {tool.name}: {e}")
 
         # Cleanup sandbox if it's managed by this agent
-        if hasattr(self.sandbox, 'down'):
+        if hasattr(self.sandbox, "down"):
             try:
                 await self.sandbox.down()
-                logger.debug('Cleaned up sandbox')
+                logger.debug("Cleaned up sandbox")
             except Exception as e:
-                logger.warning(f'Error cleaning up sandbox: {e}')
+                logger.warning(f"Error cleaning up sandbox: {e}")
 
-        logger.debug('CodeAgent cleanup completed')
+        logger.debug("CodeAgent cleanup completed")
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -1265,26 +1264,26 @@ class CodeAgent(Agent):
     def _message_to_llm_dict(msg: Message) -> dict[str, _t.Any]:
         """Convert A2A :class:`Message` to OpenAI message dict."""
         if not msg.parts:
-            raise ValueError('Message parts is empty')
+            raise ValueError("Message parts is empty")
 
         # Concatenate text parts for now – richer multipart support can be added later
         text_parts = []
         for p in msg.parts:
             # Handle Part objects that contain TextPart objects
-            if hasattr(p, 'root') and hasattr(p.root, 'text'):
+            if hasattr(p, "root") and hasattr(p.root, "text"):
                 text_parts.append(p.root.text)
             # Handle direct TextPart objects
-            elif hasattr(p, 'text'):
+            elif hasattr(p, "text"):
                 text_parts.append(p.text)
 
-        content_str = '\n'.join(text_parts)
+        content_str = "\n".join(text_parts)
         role_map = {
-            Role.user: 'user',
-            Role.agent: 'assistant',
+            Role.user: "user",
+            Role.agent: "assistant",
         }
         return {
-            'role': role_map[msg.role],
-            'content': content_str,
+            "role": role_map[msg.role],
+            "content": content_str,
         }
 
     def _detect_and_intervene_loop(
@@ -1305,14 +1304,14 @@ class CodeAgent(Agent):
                 return self._generate_intervention_and_fix(repeated_call, original_user_input, tool_calls)
 
             # Check for similar calls (same tool and file path, but different content)
-            if all(call.startswith('sandbox_write_file:') for call in recent_calls):
+            if all(call.startswith("sandbox_write_file:") for call in recent_calls):
                 # Extract file paths
-                file_paths = [call.split(':', 1)[1] for call in recent_calls]
+                file_paths = [call.split(":", 1)[1] for call in recent_calls]
                 if len(set(file_paths)) == 1:  # Same file being written multiple times
                     file_path = file_paths[0]
-                    if f'sandbox_write_file:{file_path}' in self._completed_actions:
+                    if f"sandbox_write_file:{file_path}" in self._completed_actions:
                         return self._generate_intervention_and_fix(
-                            f'sandbox_write_file:{file_path}', original_user_input, tool_calls
+                            f"sandbox_write_file:{file_path}", original_user_input, tool_calls
                         )
 
         return None, tool_calls
@@ -1321,55 +1320,54 @@ class CodeAgent(Agent):
         self, repeated_call: str, original_user_input: str, tool_calls: list[ToolCall]
     ) -> tuple[str, list[ToolCall]]:
         """Generate intervention message and modify tool calls to force progression."""
-        if repeated_call.startswith('sandbox_write_file:'):
+        if repeated_call.startswith("sandbox_write_file:"):
             # Extract the file path
-            file_path = repeated_call.split(':', 1)[1]
+            file_path = repeated_call.split(":", 1)[1]
 
             # Check if this is a "create and run" scenario
-            if any(keyword in original_user_input.lower() for keyword in ['run', 'execute', 'and run']):
+            if any(keyword in original_user_input.lower() for keyword in ["run", "execute", "and run"]):
                 intervention_msg = (
-                    f'SYSTEM INTERVENTION: The file {file_path} has been successfully created multiple times. '
-                    f'Proceeding to execute it instead of recreating it.'
+                    f"SYSTEM INTERVENTION: The file {file_path} has been successfully created multiple times. "
+                    f"Proceeding to execute it instead of recreating it."
                 )
 
                 # Force the correct tool call - replace any sandbox_write_file calls with sandbox_exec
                 modified_calls = []
                 for call in tool_calls:
-                    if call.name == 'sandbox_write_file' and call.arguments.get('path') == file_path:
+                    if call.name == "sandbox_write_file" and call.arguments.get("path") == file_path:
                         # Replace with execution call
-                        if file_path.endswith('.py'):
+                        if file_path.endswith(".py"):
                             exec_call = ToolCall(
-                                call_id=call.call_id, name='sandbox_exec', arguments={'cmd': f'python {file_path}'}
+                                call_id=call.call_id, name="sandbox_exec", arguments={"cmd": f"python {file_path}"}
                             )
                         else:
                             exec_call = ToolCall(
-                                call_id=call.call_id, name='sandbox_exec', arguments={'cmd': file_path}
+                                call_id=call.call_id, name="sandbox_exec", arguments={"cmd": file_path}
                             )
                         modified_calls.append(exec_call)
                     else:
                         modified_calls.append(call)
 
                 # If no write calls were found, add the execution call
-                if not any(call.name == 'sandbox_write_file' for call in tool_calls):
-                    if file_path.endswith('.py'):
+                if not any(call.name == "sandbox_write_file" for call in tool_calls):
+                    if file_path.endswith(".py"):
                         exec_call = ToolCall(
-                            call_id=str(uuid.uuid4()), name='sandbox_exec', arguments={'cmd': f'python {file_path}'}
+                            call_id=str(uuid.uuid4()), name="sandbox_exec", arguments={"cmd": f"python {file_path}"}
                         )
                     else:
                         exec_call = ToolCall(
-                            call_id=str(uuid.uuid4()), name='sandbox_exec', arguments={'cmd': file_path}
+                            call_id=str(uuid.uuid4()), name="sandbox_exec", arguments={"cmd": file_path}
                         )
                     modified_calls.append(exec_call)
 
                 return intervention_msg, modified_calls
             intervention_msg = (
-                f'SYSTEM INTERVENTION: The file {file_path} has been successfully created.'
-                ' Task is complete.'
+                f"SYSTEM INTERVENTION: The file {file_path} has been successfully created. Task is complete."
             )
             return intervention_msg, []  # No more tool calls needed
 
         return (
-            'SYSTEM INTERVENTION: You appear to be repeating the same action. Please proceed to the next step.',
+            "SYSTEM INTERVENTION: You appear to be repeating the same action. Please proceed to the next step.",
             tool_calls,
         )
 
@@ -1379,19 +1377,19 @@ class CodeAgent(Agent):
 
         def clean_value(value):
             """Recursively clean a value to make it JSON serializable."""
-            if hasattr(value, '__class__') and value.__class__.__name__ == 'Undefined':
+            if hasattr(value, "__class__") and value.__class__.__name__ == "Undefined":
                 return None
             if isinstance(value, dict):
                 return {
                     k: clean_value(v)
                     for k, v in value.items()
-                    if not (hasattr(v, '__class__') and v.__class__.__name__ == 'Undefined')
+                    if not (hasattr(v, "__class__") and v.__class__.__name__ == "Undefined")
                 }
             if isinstance(value, list | tuple):
                 return [
                     clean_value(item)
                     for item in value
-                    if not (hasattr(item, '__class__') and item.__class__.__name__ == 'Undefined')
+                    if not (hasattr(item, "__class__") and item.__class__.__name__ == "Undefined")
                 ]
             if isinstance(value, str | int | float | bool | type(None)):
                 return value

--- a/src/codin/agent/search_agent.py
+++ b/src/codin/agent/search_agent.py
@@ -1,0 +1,159 @@
+"""Agent implementation that performs simple search over planner suggestions.
+
+This agent runs the planner multiple times per turn, evaluates the candidate
+step sequences and executes the one with the highest score.  It inherits most
+functionality from :class:`BaseAgent` and only overrides the planning loop.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+import typing as _t
+
+
+from .base_agent import BaseAgent
+from .types import (
+    AgentRunOutput,
+    FinishStep,
+    Message,
+    MessageStep,
+    Role,
+    State,
+    Step,
+    StepType,
+    TextPart,
+)
+
+__all__ = ["SearchAgent"]
+
+
+class SearchAgent(BaseAgent):
+    """Agent that evaluates multiple planner outputs each turn."""
+
+    def __init__(self, *args, search_width: int = 3, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.search_width = max(1, search_width)
+
+    async def _execute_planning_loop(
+        self, state: State, session_id: str, start_time: float
+    ) -> _t.AsyncGenerator[AgentRunOutput]:
+        """Execute planning loop with naive search strategy."""
+
+        await self._emit_event(
+            "task_start",
+            {"session_id": session_id, "iteration": state.iteration, "elapsed_time": 0.0},
+        )
+
+        while state.iteration < (state.config.turn_budget or 100):
+            search_width = int(state.metadata.get("badgers", self.search_width))
+            should_continue = await self.check_inbox_for_control()
+            if not should_continue:
+                break
+            if self._paused:
+                await self.wait_while_paused()
+                if self._cancelled:
+                    break
+
+            elapsed_time = time.time() - start_time
+            state.metrics.time_used = elapsed_time
+            exceeded, reason = state.config.is_budget_exceeded(state.metrics, elapsed_time)
+            if exceeded:
+                finish_reason = f"Budget exceeded: {reason}"
+                finish_msg = Message(
+                    messageId=str(uuid.uuid4()),
+                    role=Role.agent,
+                    parts=[TextPart(text=finish_reason)],
+                    contextId=session_id,
+                    kind="message",
+                )
+                finish_step = FinishStep(step_id=str(uuid.uuid4()), reason=finish_reason, final_message=finish_msg)
+                await self.mailbox.put_outbox(finish_msg)
+                async for output in self._execute_step(finish_step, state, session_id):
+                    yield output
+                break
+
+            await self._emit_event(
+                "turn_start",
+                {"session_id": session_id, "iteration": state.iteration, "metrics": state.metrics.__dict__},
+            )
+
+            candidate_runs: list[list[Step]] = []
+            for _ in range(search_width):
+                steps: list[Step] = []
+                async for s in self.planner.next(state):
+                    steps.append(s)
+                    if len(steps) >= 10 or s.step_type == StepType.FINISH:
+                        break
+                candidate_runs.append(steps)
+                if hasattr(self.planner, "reset"):
+                    await self.planner.reset(state)
+
+            def score(steps: list[Step]) -> int:
+                val = 0
+                for st in steps:
+                    if st.step_type == StepType.FINISH:
+                        val += 100
+                    elif st.step_type == StepType.MESSAGE:
+                        val += 10
+                    elif st.step_type == StepType.TOOL_CALL:
+                        val += 5
+                    elif st.step_type == StepType.THINK:
+                        val += 1
+                return val
+
+            best_steps = max(candidate_runs, key=score) if candidate_runs else []
+
+            steps_executed = 0
+            task_finished = False
+            for step in best_steps:
+                should_continue = await self.check_inbox_for_control()
+                if not should_continue:
+                    break
+                if self._paused:
+                    await self.wait_while_paused()
+                    if self._cancelled:
+                        break
+
+                steps_executed += 1
+                if step.step_type == StepType.MESSAGE and isinstance(step, MessageStep) and step.message:
+                    if not any(h.messageId == step.message.messageId for h in state.history if h.messageId and step.message.messageId):
+                        await self.memory.add_message(step.message)
+                        state.history.append(step.message)
+
+                async for output in self._execute_step(step, state, session_id):
+                    yield output
+
+                if step.step_type == StepType.FINISH:
+                    task_finished = True
+                    await self._emit_event(
+                        "task_complete",
+                        {
+                            "session_id": session_id,
+                            "iteration": state.iteration,
+                            "reason": step.reason if isinstance(step, FinishStep) and step.reason else "Finished",
+                        },
+                    )
+                    break
+
+                if steps_executed >= 10:
+                    break
+
+            if task_finished or self._cancelled:
+                break
+
+            state.iteration += 1
+            await self._emit_event(
+                "turn_end",
+                {"session_id": session_id, "iteration": state.iteration, "steps_executed": steps_executed},
+            )
+
+        await self._emit_event(
+            "task_end",
+            {
+                "session_id": session_id,
+                "iteration": state.iteration,
+                "elapsed_time": time.time() - start_time,
+            },
+        )
+

--- a/src/codin/cli/commands.py
+++ b/src/codin/cli/commands.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 
 import click
-from a2a.types import Message, Role, TextPart
+from codin.agent.types import Message, Role, TextPart
 from dotenv import load_dotenv
 
 from ..agent.base import AgentRunInput
@@ -51,9 +51,7 @@ def validate_approval_mode(mode: str) -> ApprovalMode:
         return ApprovalMode(mode)
     except ValueError as err:
         available = ", ".join([m.value for m in ApprovalMode])
-        raise click.BadParameter(
-            f"Unknown approval mode '{mode}'. Available: {available}"
-        ) from err
+        raise click.BadParameter(f"Unknown approval mode '{mode}'. Available: {available}") from err
 
 
 async def run_quiet_mode(

--- a/src/codin/cli/repl.py
+++ b/src/codin/cli/repl.py
@@ -10,8 +10,8 @@ import logging
 
 import click
 
-# Use a2a types instead of internal protocol types
-from a2a.types import Message, Role, TextPart
+# Use agent protocol types
+from codin.agent.types import Message, Role, TextPart
 
 from ..agent.base import AgentRunInput
 from ..agent.code_agent import CodeAgent
@@ -269,9 +269,7 @@ class ReplSession:
                             elif tool_name in ["sandbox_exec", "shell", "container_exec"]:
                                 if output.strip():
                                     lines = output.strip().split("\n")
-                                    click.echo(
-                                        f"  📤 Output ({len(lines)} lines):\n{output.strip()}"
-                                    )
+                                    click.echo(f"  📤 Output ({len(lines)} lines):\n{output.strip()}")
                             elif tool_name == "sandbox_write_file":
                                 click.echo("  💾 File written successfully")
                     else:
@@ -314,16 +312,14 @@ class ReplSession:
                     click.echo()
                     click.echo(
                         click.style(
-                            f'🤖 LLM Response (Turn {debug_info["turn_count"]}):',
+                            f"🤖 LLM Response (Turn {debug_info['turn_count']}):",
                             bold=True,
                             fg="cyan",
                         )
                     )
                     click.echo(click.style("-" * 60, fg="cyan"))
 
-                    click.echo(
-                        f'📄 Raw content length: {debug_info["raw_content_length"]} characters'
-                    )
+                    click.echo(f"📄 Raw content length: {debug_info['raw_content_length']} characters")
 
                     thinking = debug_info.get("thinking")
                     if thinking:
@@ -337,12 +333,12 @@ class ReplSession:
                     else:
                         click.echo("💬 Message: None")
 
-                    click.echo(f'🔄 Should continue: {debug_info["should_continue"]}')
+                    click.echo(f"🔄 Should continue: {debug_info['should_continue']}")
 
                     task_list = debug_info["task_list"]
                     click.echo(
-                        f'📋 Task list - Completed: {task_list["completed_count"]}, '
-                        f'Pending: {task_list["pending_count"]}'
+                        f"📋 Task list - Completed: {task_list['completed_count']}, "
+                        f"Pending: {task_list['pending_count']}"
                     )
 
                     tool_calls = debug_info.get("tool_calls", [])
@@ -350,7 +346,7 @@ class ReplSession:
                         click.echo(f"🔧 Tool calls: {len(tool_calls)}")
                         for i, tool_call in enumerate(tool_calls):
                             args_keys = tool_call.get("arguments_keys", [])
-                            click.echo(f'  {i + 1}. {tool_call["name"]}({args_keys})')
+                            click.echo(f"  {i + 1}. {tool_call['name']}({args_keys})")
                     else:
                         click.echo("🔧 Tool calls: None")
 
@@ -566,7 +562,7 @@ class ReplSession:
                 other_formatted.append(f"{key}={formatted_value}")
 
             if other_formatted:
-                click.echo(f'  📋 Additional args: {", ".join(other_formatted)}')
+                click.echo(f"  📋 Additional args: {', '.join(other_formatted)}")
 
     def _format_argument_value(self, key: str, value, max_length: int | None = None) -> str:
         """Format an argument value for display.
@@ -696,7 +692,7 @@ class ReplSession:
 
         click.echo(f"  Approval Mode: {self.config.approval_mode.value}")
         click.echo(f"  Verbose: {self.config.verbose}")
-        click.echo(f'  Project Docs: {"enabled" if self.config.enable_rules else "disabled"}')
+        click.echo(f"  Project Docs: {'enabled' if self.config.enable_rules else 'disabled'}")
         click.echo()
 
     def display_history(self) -> None:
@@ -837,16 +833,12 @@ class ReplSession:
                 error_str = str(e).lower()
                 if "timeout" in error_str or "timed out" in error_str:
                     click.echo(f"\n[WARN] Request timed out: {e}")
-                    click.echo(
-                        "This might be due to network issues or high server load. Please try again."
-                    )
+                    click.echo("This might be due to network issues or high server load. Please try again.")
                 elif "connection" in error_str or "network" in error_str:
                     click.echo(f"\n[WARN] Network error: {e}")
                     click.echo("Please check your internet connection and try again.")
                 elif "cancelled" in error_str:
-                    click.echo(
-                        "\n[WARN] Request was cancelled. This might be due to cleanup during shutdown."
-                    )
+                    click.echo("\n[WARN] Request was cancelled. This might be due to cleanup during shutdown.")
                     return True
                 else:
                     # Re-raise for general error handling below

--- a/src/codin/memory/base.py
+++ b/src/codin/memory/base.py
@@ -7,7 +7,7 @@ import typing as _t
 from datetime import datetime
 from enum import Enum
 
-from a2a.types import Message, Role, TextPart
+from codin.agent.types import Message, Role, TextPart
 from pydantic import BaseModel, Field
 
 __all__ = [
@@ -124,14 +124,10 @@ class Memory(abc.ABC):
     ) -> None: ...
 
     @abc.abstractmethod
-    async def build_chunk(
-        self, start_index: int | None = None, end_index: int | None = None
-    ) -> int: ...
+    async def build_chunk(self, start_index: int | None = None, end_index: int | None = None) -> int: ...
 
     @abc.abstractmethod
-    async def search_chunk(
-        self, session_id: str, query: str, limit: int = 5
-    ) -> list[MemoryChunk]: ...
+    async def search_chunk(self, session_id: str, query: str, limit: int = 5) -> list[MemoryChunk]: ...
 
 
 MemoryService = Memory

--- a/src/codin/memory/chunk_builder.py
+++ b/src/codin/memory/chunk_builder.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from datetime import datetime
 
-from a2a.types import Message, Role
+from codin.agent.types import Message, Role
 
 from ..prompt import prompt_run
 from .base import ChunkType, MemoryChunk

--- a/src/codin/memory/local.py
+++ b/src/codin/memory/local.py
@@ -6,7 +6,7 @@ import typing as _t
 import uuid
 from datetime import datetime
 
-from a2a.types import Message, Role
+from codin.agent.types import Message, Role
 
 from .base import ChunkType, Memory, MemoryChunk
 
@@ -63,12 +63,7 @@ class _LanceIndex:
 
     def search(self, session_id: str, query: str, limit: int) -> list[str]:
         vector = _hash_embed(query)
-        df = (
-            self.table.search(vector)
-            .where(f"session_id == '{session_id}'")
-            .limit(limit)
-            .to_pandas()
-        )
+        df = self.table.search(vector).where(f"session_id == '{session_id}'").limit(limit).to_pandas()
         return df.get("chunk_id", []).tolist()
 
 
@@ -159,9 +154,7 @@ class MemMemoryService(Memory):
 
         return await self._create_memory_chunk_legacy(session_id, messages, llm_summarizer)
 
-    async def search_memory_chunks(
-        self, session_id: str, query: str, limit: int = 5
-    ) -> list[MemoryChunk]:
+    async def search_memory_chunks(self, session_id: str, query: str, limit: int = 5) -> list[MemoryChunk]:
         """Alias for :meth:`search_chunk` for backward compatibility."""
 
         return await self.search_chunk(session_id, query, limit)
@@ -224,9 +217,7 @@ class MemMemoryService(Memory):
         for i in range(0, len(to_compress), chunk_size):
             chunk_msgs = to_compress[i : i + chunk_size]
             if chunk_msgs:
-                await self._create_memory_chunk_legacy(
-                    session_id, chunk_msgs, llm_summarizer
-                )
+                await self._create_memory_chunk_legacy(session_id, chunk_msgs, llm_summarizer)
                 chunk_groups_created += 1
         self._messages[session_id] = messages[-keep_recent:]
         return chunk_groups_created

--- a/src/codin/memory/remote.py
+++ b/src/codin/memory/remote.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import typing as _t
 
-from a2a.types import Message
+from codin.agent.types import Message
 
 from ..client import Client, ClientConfig
 from .base import Memory, MemoryChunk

--- a/src/codin/prompt/base.py
+++ b/src/codin/prompt/base.py
@@ -18,21 +18,11 @@ import hashlib
 import typing as _t
 from datetime import datetime
 
-from a2a.types import (
+from codin.agent.types import (
     DataPart as A2ADataPart,
-)
-from a2a.types import (
     FilePart as A2AFilePart,
-)
-
-# A2A SDK imports
-from a2a.types import (
     Message as A2AMessage,
-)
-from a2a.types import (
     Role as A2ARole,
-)
-from a2a.types import (
     TextPart as A2ATextPart,
 )
 from pydantic import BaseModel, ConfigDict
@@ -46,25 +36,25 @@ except ImportError:  # pragma: no cover
     _JinjaTemplate = None
 
 __all__ = [
-    'A2ADataPart',
-    'A2AFilePart',
-    'A2AMessage',
-    'A2APart',
-    'A2ARole',
-    'A2ATextPart',
-    'ModelOptions',
-    'PromptResponse',
-    'PromptTemplate',
-    'PromptVariant',
-    'RenderedPrompt',
-    'ToolDefinition',
+    "A2ADataPart",
+    "A2AFilePart",
+    "A2AMessage",
+    "A2APart",
+    "A2ARole",
+    "A2ATextPart",
+    "ModelOptions",
+    "PromptResponse",
+    "PromptTemplate",
+    "PromptVariant",
+    "RenderedPrompt",
+    "ToolDefinition",
 ]
 
 # -----------------------------------------------------------------------------
 # A2A Protocol Support
 # -----------------------------------------------------------------------------
 
-# Re-export a2a types for backward compatibility
+# Re-export agent types for backward compatibility
 A2AMessage = A2AMessage
 
 # Union type for all part types
@@ -155,7 +145,7 @@ class PromptVariant(BaseModel):
             actual = conditions.get(key)
 
             # Simple equality check with some smart matching
-            if key in ('model_family', 'model_provider'):
+            if key in ("model_family", "model_provider"):
                 # Prefix matching for model families/providers
                 if actual and required:
                     if not str(actual).lower().startswith(str(required).lower()):
@@ -184,7 +174,7 @@ class PromptVariant(BaseModel):
             actual = conditions.get(key)
             if actual == required:
                 score += 10  # Exact match
-            elif key in ('model_family', 'model_provider') and actual and required:
+            elif key in ("model_family", "model_provider") and actual and required:
                 if str(actual).lower().startswith(str(required).lower()):
                     score += 5  # Prefix match
 
@@ -234,7 +224,7 @@ class PromptTemplate:
     def __init__(
         self,
         name: str,
-        version: str = 'latest',
+        version: str = "latest",
         variants: list[PromptVariant] | None = None,
         metadata: dict[str, _t.Any] | None = None,
         text: str | None = None,
@@ -284,7 +274,7 @@ class PromptTemplate:
         matches.sort(key=lambda x: x[1], reverse=True)
         return matches[0][0]
 
-    def render(self, conditions: dict[str, _t.Any] | None = None, **variables: _t.Any) -> 'RenderedPrompt':
+    def render(self, conditions: dict[str, _t.Any] | None = None, **variables: _t.Any) -> "RenderedPrompt":
         """Render the template with the best matching variant."""
         variant = self.get_best_variant(conditions)
         if not variant:
@@ -309,7 +299,7 @@ class PromptTemplate:
         """Get the text of the first variant (for backward compatibility)."""
         if self.variants:
             return self.variants[0].text
-        return ''
+        return ""
 
 
 class RenderedPrompt(BaseModel):
@@ -340,6 +330,6 @@ class RenderedPrompt(BaseModel):
 
         messages = []
         if self.system_prompt:
-            messages.append({'role': 'system', 'content': self.system_prompt})
-        messages.append({'role': 'user', 'content': self.text})
+            messages.append({"role": "system", "content": self.system_prompt})
+        messages.append({"role": "user", "content": self.text})
         return messages

--- a/src/codin/prompt/run.py
+++ b/src/codin/prompt/run.py
@@ -11,14 +11,14 @@ from __future__ import annotations
 import typing as _t
 import uuid
 
-# Use a2a SDK types directly
-from a2a.types import Message, Role, TextPart
+# Use agent protocol types directly
+from codin.agent.types import Message, Role, TextPart
 
 from .base import PromptResponse, ToolDefinition
 from .engine import PromptEngine
 from .registry import set_endpoint
 
-__all__ = ['prompt_run', 'render_only', 'set_endpoint']
+__all__ = ["prompt_run", "render_only", "set_endpoint"]
 
 # Global engine instance for convenience
 _engine: PromptEngine | None = None
@@ -42,10 +42,10 @@ def _convert_tools(tools: list[ToolDefinition | dict] | None) -> list[ToolDefini
         if isinstance(tool, dict):
             converted.append(
                 ToolDefinition(
-                    name=tool.get('name', ''),
-                    description=tool.get('description', ''),
-                    parameters=tool.get('parameters', {}),
-                    metadata=tool.get('metadata'),
+                    name=tool.get("name", ""),
+                    description=tool.get("description", ""),
+                    parameters=tool.get("parameters", {}),
+                    metadata=tool.get("metadata"),
                 )
             )
         else:
@@ -61,16 +61,16 @@ def _convert_history(history: list[Message | dict] | None) -> list[Message] | No
     converted = []
     for msg in history:
         if isinstance(msg, dict):
-            role = Role.user if msg.get('role') == 'user' else Role.agent
-            content = msg.get('content', '')
+            role = Role.user if msg.get("role") == "user" else Role.agent
+            content = msg.get("content", "")
 
             a2a_msg = Message(
-                message_id=msg.get('message_id', str(uuid.uuid4())),
+                message_id=msg.get("message_id", str(uuid.uuid4())),
                 role=role,
                 parts=[TextPart(text=content)],
-                context_id=msg.get('context_id'),
-                task_id=msg.get('task_id'),
-                metadata=msg.get('metadata'),
+                context_id=msg.get("context_id"),
+                task_id=msg.get("task_id"),
+                metadata=msg.get("metadata"),
             )
             converted.append(a2a_msg)
         else:
@@ -118,7 +118,7 @@ async def prompt_run(
     engine = _get_engine()
 
     # Extract history from kwargs if provided
-    history = kwargs.pop('history', None)
+    history = kwargs.pop("history", None)
 
     return await engine.run(
         name,

--- a/src/codin/tool/mcp/conversion_utils.py
+++ b/src/codin/tool/mcp/conversion_utils.py
@@ -13,23 +13,23 @@ from __future__ import annotations
 
 import typing as _t
 
-from a2a.types import DataPart, FilePart, TextPart
+from codin.agent.types import DataPart, FilePart, TextPart
 
 __all__ = [
-    'convert_mcp_to_protocol_types',
+    "convert_mcp_to_protocol_types",
 ]
 
 
 def _is_text_part(data: dict[str, _t.Any]) -> bool:
-    return data.get('type') == 'text' and 'text' in data
+    return data.get("type") == "text" and "text" in data
 
 
 def _is_data_part(data: dict[str, _t.Any]) -> bool:
-    return data.get('type') == 'data' and 'data' in data and isinstance(data['data'], dict)
+    return data.get("type") == "data" and "data" in data and isinstance(data["data"], dict)
 
 
 def _is_file_part(data: dict[str, _t.Any]) -> bool:
-    return data.get('type') == 'file' and 'file' in data and isinstance(data['file'], dict)
+    return data.get("type") == "file" and "file" in data and isinstance(data["file"], dict)
 
 
 def _convert_single(obj: _t.Any) -> _t.Any:
@@ -45,15 +45,15 @@ def _convert_single(obj: _t.Any) -> _t.Any:
     # Dictionaries may represent protocol parts.
     if isinstance(obj, dict):
         if _is_text_part(obj):
-            return TextPart(text=_t.cast(str, obj['text']))
+            return TextPart(text=_t.cast(str, obj["text"]))
         if _is_data_part(obj):
-            return DataPart(data=_t.cast(dict[str, _t.Any], obj['data']), mime_type='application/json')
+            return DataPart(data=_t.cast(dict[str, _t.Any], obj["data"]), mime_type="application/json")
         if _is_file_part(obj):
-            file_dict = _t.cast(dict[str, _t.Any], obj['file'])
+            file_dict = _t.cast(dict[str, _t.Any], obj["file"])
             return FilePart(
-                file_id=file_dict.get('uri', file_dict.get('name', 'unknown')),
-                mime_type=file_dict.get('mimeType'),
-                name=file_dict.get('name'),
+                file_id=file_dict.get("uri", file_dict.get("name", "unknown")),
+                mime_type=file_dict.get("mimeType"),
+                name=file_dict.get("name"),
             )
         # Fallback – return a recursively converted dictionary.
         return {key: _convert_single(val) for key, val in obj.items()}

--- a/src/codin/utils/message.py
+++ b/src/codin/utils/message.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from a2a.types import Message
+from codin.agent.types import Message
 
 __all__ = [
     "extract_text_from_message",

--- a/tests/actor/mailbox_test.py
+++ b/tests/actor/mailbox_test.py
@@ -4,7 +4,7 @@ import asyncio
 import pytest
 from datetime import datetime
 
-from a2a.types import Message, Role, TextPart
+from codin.agent.types import Message, Role, TextPart
 
 from codin.actor import (
     Mailbox,
@@ -22,33 +22,21 @@ from codin.agent.types import ControlSignal, RunnerControl, RunnerInput
 async def test_local_mailbox():
     """Test the LocalMailbox implementation."""
     mailbox = LocalMailbox(maxsize=10)
-    
+
     # Test basic inbox/outbox operations
-    msg1 = Message(
-        messageId="msg1",
-        role=Role.user,
-        parts=[TextPart(text="Hello")],
-        contextId="test",
-        kind="message"
-    )
-    
+    msg1 = Message(messageId="msg1", role=Role.user, parts=[TextPart(text="Hello")], contextId="test", kind="message")
+
     # Put message in inbox
     await mailbox.put_inbox(msg1)
-    
+
     # Get message from inbox
     received = (await mailbox.get_inbox(timeout=1.0))[0]
     assert received.messageId == "msg1"
     assert received.parts[0].root.text == "Hello"
-    
+
     # Test outbox
-    msg2 = Message(
-        messageId="msg2",
-        role=Role.agent,
-        parts=[TextPart(text="World")],
-        contextId="test",
-        kind="message"
-    )
-    
+    msg2 = Message(messageId="msg2", role=Role.agent, parts=[TextPart(text="World")], contextId="test", kind="message")
+
     await mailbox.put_outbox(msg2)
     received_out = (await mailbox.get_outbox(timeout=1.0))[0]
     assert received_out.messageId == "msg2"
@@ -96,8 +84,7 @@ async def test_local_mailbox():
 async def test_local_actor_manager():
     """Test the LocalActorManager implementation."""
     from codin.agent.base import Agent
-    from codin.agent.types import AgentRunInput, AgentRunOutput, Message
-    from a2a.types import Role, TextPart
+    from codin.agent.types import AgentRunInput, AgentRunOutput, Message, Role, TextPart
 
     class DummyAgent(Agent):
         def __init__(self, agent_id: str):
@@ -112,27 +99,28 @@ async def test_local_actor_manager():
         return DummyAgent(f"{actor_type}:{key}")
 
     from codin.actor.supervisor import ActorInfo
+
     ActorInfo.model_rebuild()
     manager = LocalActorManager(agent_factory=factory)
-    
+
     # Test acquire
     agent1 = await manager.acquire("test_agent", "key1")
     assert agent1 is not None
-    assert hasattr(agent1, 'agent_id')
-    
+    assert hasattr(agent1, "agent_id")
+
     # Test getting same agent
     agent2 = await manager.acquire("test_agent", "key1")
     assert agent1 is agent2  # Should be same instance
-    
+
     # Test list actors
     actors = await manager.list()
     assert len(actors) == 1
     assert actors[0].actor_type == "test_agent"
-    
+
     # Test release
     agent_id = actors[0].actor_id
     await manager.release(agent_id)
-    
+
     # Should be empty now
     actors_after = await manager.list()
     assert len(actors_after) == 0
@@ -143,7 +131,7 @@ async def test_local_dispatcher():
     """Test the LocalDispatcher implementation."""
     manager = LocalActorManager()
     dispatcher = LocalDispatcher(manager)
-    
+
     # Test submit request
     a2a_request = {
         "contextId": "test_context",
@@ -151,26 +139,26 @@ async def test_local_dispatcher():
             "messageId": "test_msg",
             "role": "user",
             "parts": [{"kind": "text", "text": "Test message"}],
-            "kind": "message"
-        }
+            "kind": "message",
+        },
     }
-    
+
     runner_id = await dispatcher.submit(a2a_request)
     assert runner_id.startswith("run_")
-    
+
     # Test get status
     status = await dispatcher.get_status(runner_id)
     assert status is not None
     assert status.runner_id == runner_id
     assert status.status in ("started", "completed", "failed")
-    
+
     # Wait a bit for processing
     await asyncio.sleep(0.1)
-    
+
     # Test list active runs
     active_runs = await dispatcher.list_active_runs()
     assert len(active_runs) >= 1
-    
+
     # Clean up
     await dispatcher.cleanup()
 
@@ -182,21 +170,15 @@ async def test_control_signals():
     control = RunnerControl(signal=ControlSignal.PAUSE)
     assert control.signal == ControlSignal.PAUSE
     assert isinstance(control.timestamp, datetime)
-    
+
     # Test runner input from control
     runner_input = RunnerInput.from_control(ControlSignal.RESUME, {"test": "metadata"})
     assert runner_input.control is not None
     assert runner_input.control.signal == ControlSignal.RESUME
     assert runner_input.control.metadata["test"] == "metadata"
-    
+
     # Test runner input from message
-    message = Message(
-        messageId="test",
-        role=Role.user,
-        parts=[TextPart(text="Test")],
-        contextId="test",
-        kind="message"
-    )
+    message = Message(messageId="test", role=Role.user, parts=[TextPart(text="Test")], contextId="test", kind="message")
     runner_input2 = RunnerInput.from_message(message)
     assert runner_input2.message is not None
     assert runner_input2.message.messageId == "test"
@@ -206,11 +188,11 @@ async def test_control_signals():
 async def test_mailbox_timeout():
     """Test mailbox timeout behavior."""
     mailbox = LocalMailbox()
-    
+
     # Test timeout on empty inbox
     with pytest.raises(asyncio.TimeoutError):
         await mailbox.get_inbox(timeout=0.1)
-    
+
     # Test timeout on empty outbox
     with pytest.raises(asyncio.TimeoutError):
         await mailbox.get_outbox(timeout=0.1)
@@ -220,22 +202,22 @@ async def test_mailbox_timeout():
 async def test_mailbox_subscription():
     """Test mailbox subscription patterns."""
     mailbox = LocalMailbox()
-    
+
     # Put a message in inbox
     msg = Message(
         messageId="sub_test",
         role=Role.user,
         parts=[TextPart(text="Subscription test")],
         contextId="test",
-        kind="message"
+        kind="message",
     )
     await mailbox.put_inbox(msg)
-    
+
     # Test subscription
     async def check_subscription():
         async for message in mailbox.subscribe_inbox():
             assert message.messageId == "sub_test"
             break  # Exit after first message
-    
+
     # Run subscription check with timeout
-    await asyncio.wait_for(check_subscription(), timeout=1.0) 
+    await asyncio.wait_for(check_subscription(), timeout=1.0)

--- a/tests/actor/ray_mailbox_test.py
+++ b/tests/actor/ray_mailbox_test.py
@@ -1,5 +1,5 @@
 import pytest
-from a2a.types import Message, Role, TextPart
+from codin.agent.types import Message, Role, TextPart
 
 from codin.actor.mailbox import RayMailbox
 

--- a/tests/actor/test_dispatcher_reconnect.py
+++ b/tests/actor/test_dispatcher_reconnect.py
@@ -15,7 +15,7 @@ from codin.agent.types import (
     AgentRunOutput,
     Task,
 )
-from a2a.types import TaskStatusUpdateEvent, TaskStatus, TaskState
+from codin.agent.types import TaskStatusUpdateEvent, TaskStatus, TaskState
 from codin.model.base import BaseLLM
 
 
@@ -103,7 +103,6 @@ async def agent_factory(agent_type: str, key: str) -> BaseAgent:
         planner=DummyPlanner(),
         llm=DummyLLM("mock-llm"),
     )
-
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_debug_events.py
+++ b/tests/agent/test_debug_events.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 from src.codin.agent.code_agent import CodeAgent, AgentEvent
 from src.codin.sandbox import LocalSandbox
 from src.codin.tool.registry import ToolRegistry
-from a2a.types import Role, TextPart
+from codin.agent.types import Role, TextPart
 from src.codin.agent.types import Message, AgentRunInput
 
 
@@ -21,28 +21,28 @@ class TestDebugEvents:
         sandbox = MagicMock()
         sandbox.up = AsyncMock()
         sandbox.down = AsyncMock()
-        
+
         agent = CodeAgent(
             name="Test Agent",
             description="Test agent for debug events",
             llm_model="test-model",
             sandbox=sandbox,
-            debug=True  # Enable debug mode
+            debug=True,  # Enable debug mode
         )
-        
+
         # Mock the LLM to return a structured response
         mock_response = MagicMock()
         mock_response.content = (
             '{"thinking": "Test thinking", "message": "Test message", "should_continue": false, '
             '"task_list": {"completed": [], "pending": []}, "tool_calls": []}'
         )
-        
+
         # Mock the model's run method
         agent._model = MagicMock()
         agent._model.run = AsyncMock(return_value=mock_response)
-        
+
         yield agent
-        
+
         await agent.cleanup()
 
     @pytest.fixture
@@ -52,28 +52,28 @@ class TestDebugEvents:
         sandbox = MagicMock()
         sandbox.up = AsyncMock()
         sandbox.down = AsyncMock()
-        
+
         agent = CodeAgent(
             name="Test Agent",
             description="Test agent without debug",
             llm_model="test-model",
             sandbox=sandbox,
-            debug=False  # Disable debug mode
+            debug=False,  # Disable debug mode
         )
-        
+
         # Mock the LLM to return a structured response
         mock_response = MagicMock()
         mock_response.content = (
             '{"thinking": "Test thinking", "message": "Test message", "should_continue": false, '
             '"task_list": {"completed": [], "pending": []}, "tool_calls": []}'
         )
-        
+
         # Mock the model's run method
         agent._model = MagicMock()
         agent._model.run = AsyncMock(return_value=mock_response)
-        
+
         yield agent
-        
+
         await agent.cleanup()
 
     @pytest.mark.asyncio
@@ -81,29 +81,23 @@ class TestDebugEvents:
         """Test that debug events are emitted when debug mode is enabled."""
         # Track events
         received_events = []
-        
+
         async def event_callback(event: AgentEvent):
             received_events.append(event)
-        
+
         agent_with_debug.add_event_callback(event_callback)
-        
+
         # Create a test message
-        user_message = Message(
-            messageId="test-message",
-            role=Role.user,
-            parts=[TextPart(text="Test prompt")]
-        )
-        
+        user_message = Message(messageId="test-message", role=Role.user, parts=[TextPart(text="Test prompt")])
+
         # Run the agent
         agent_input = AgentRunInput(message=user_message)
         await agent_with_debug.run(agent_input)
-        
+
         # Check that debug events were emitted
         debug_events = [e for e in received_events if e.event_type == "debug_llm_response"]
-        assert len(debug_events) > 0, (
-            "Debug events should be emitted when debug mode is enabled"
-        )
-        
+        assert len(debug_events) > 0, "Debug events should be emitted when debug mode is enabled"
+
         # Verify the debug event structure
         debug_event = debug_events[0]
         assert "turn_count" in debug_event.data
@@ -119,85 +113,72 @@ class TestDebugEvents:
         """Test that debug events are not emitted when debug mode is disabled."""
         # Track events
         received_events = []
-        
+
         async def event_callback(event: AgentEvent):
             received_events.append(event)
-        
+
         agent_without_debug.add_event_callback(event_callback)
-        
+
         # Create a test message
-        user_message = Message(
-            messageId="test-message",
-            role=Role.user,
-            parts=[TextPart(text="Test prompt")]
-        )
-        
+        user_message = Message(messageId="test-message", role=Role.user, parts=[TextPart(text="Test prompt")])
+
         # Run the agent
         agent_input = AgentRunInput(message=user_message)
         await agent_without_debug.run(agent_input)
-        
+
         # Check that no debug events were emitted
         debug_events = [e for e in received_events if e.event_type == "debug_llm_response"]
-        assert len(debug_events) == 0, (
-            "Debug events should not be emitted when debug mode is disabled"
-        )
+        assert len(debug_events) == 0, "Debug events should not be emitted when debug mode is disabled"
 
     @pytest.mark.asyncio
     async def test_debug_event_data_structure(self, agent_with_debug):
         """Test that debug event data has the correct structure."""
         # Track events
         received_events = []
-        
+
         async def event_callback(event: AgentEvent):
             received_events.append(event)
-        
+
         agent_with_debug.add_event_callback(event_callback)
-        
+
         # Mock the response parsing to return specific data
         mock_tool_call_1 = MagicMock()
         mock_tool_call_1.name = "test_tool"
         mock_tool_call_1.call_id = "call_1"
         mock_tool_call_1.arguments = {"arg1": "value1"}
-        
+
         mock_tool_call_2 = MagicMock()
         mock_tool_call_2.name = "another_tool"
         mock_tool_call_2.call_id = "call_2"
         mock_tool_call_2.arguments = {"arg2": "value2", "arg3": "value3"}
-        
+
         mock_parsed_response = {
             "thinking": "Test thinking content",
-            "message": "Test message content", 
+            "message": "Test message content",
             "should_continue": False,  # Set to False to prevent infinite loop
-            "task_list": {
-                "completed": ["Task 1", "Task 2"],
-                "pending": ["Task 3"]
-            },
-            "tool_calls": [mock_tool_call_1, mock_tool_call_2]
+            "task_list": {"completed": ["Task 1", "Task 2"], "pending": ["Task 3"]},
+            "tool_calls": [mock_tool_call_1, mock_tool_call_2],
         }
-        
+
         # Mock the parsing method
         agent_with_debug._parse_structured_response = MagicMock(return_value=mock_parsed_response)
-        
+
         # Create a test message
-        user_message = Message(
-            messageId="test-message",
-            role=Role.user,
-            parts=[TextPart(text="Test prompt")]
-        )
-        
+        user_message = Message(messageId="test-message", role=Role.user, parts=[TextPart(text="Test prompt")])
+
         # Run the agent with timeout to prevent hanging
         agent_input = AgentRunInput(message=user_message)
         try:
             await asyncio.wait_for(agent_with_debug.run(agent_input), timeout=10.0)
         except asyncio.TimeoutError:
             pytest.fail("Agent run timed out - this suggests the test is hanging")
-        
+
         # Get the debug event
         debug_events = [e for e in received_events if e.event_type == "debug_llm_response"]
         assert len(debug_events) > 0
-        
+
         debug_data = debug_events[0].data
-        
+
         # Verify the structure
         assert debug_data["thinking"] == "Test thinking content"
         assert debug_data["message"] == "Test message content"
@@ -210,4 +191,4 @@ class TestDebugEvents:
         assert debug_data["tool_calls"][0]["name"] == "test_tool"
         assert debug_data["tool_calls"][0]["arguments_keys"] == ["arg1"]
         assert debug_data["tool_calls"][1]["name"] == "another_tool"
-        assert debug_data["tool_calls"][1]["arguments_keys"] == ["arg2", "arg3"] 
+        assert debug_data["tool_calls"][1]["arguments_keys"] == ["arg2", "arg3"]

--- a/tests/agent/test_enhanced_steps.py
+++ b/tests/agent/test_enhanced_steps.py
@@ -3,11 +3,23 @@
 import pytest
 from datetime import datetime
 from codin.agent.types import (
-    Step, StepType, MessageStep, EventStep, ToolCallStep, ThinkStep, FinishStep,
-    Message, Task, ToolCall, ToolCallResult, ToolUsePart,
-    EventType, RunEvent, TaskStatusUpdateEvent
+    Step,
+    StepType,
+    MessageStep,
+    EventStep,
+    ToolCallStep,
+    ThinkStep,
+    FinishStep,
+    Message,
+    Task,
+    ToolCall,
+    ToolCallResult,
+    ToolUsePart,
+    EventType,
+    RunEvent,
+    TaskStatusUpdateEvent,
 )
-from a2a.types import TaskState, TaskStatus
+from codin.agent.types import TaskState, TaskStatus
 
 
 class TestEnhancedSteps:
@@ -16,17 +28,9 @@ class TestEnhancedSteps:
     def test_step_content_detection(self):
         """Test step content detection methods."""
         # Create a step with message content
-        message = Message(
-            messageId="test-msg",
-            role="user",
-            parts=[]
-        )
-        step = Step(
-            step_id="test-1",
-            step_type=StepType.MESSAGE,
-            message=message
-        )
-        
+        message = Message(messageId="test-msg", role="user", parts=[])
+        step = Step(step_id="test-1", step_type=StepType.MESSAGE, message=message)
+
         assert step.has_message_content()
         assert not step.has_event_content()
         assert not step.has_tool_content()
@@ -36,15 +40,15 @@ class TestEnhancedSteps:
         """Test step with mixed content types."""
         message = Message(messageId="test-msg", role="agent", parts=[])
         tool_call = ToolCall(call_id="call-1", name="test_tool", arguments={})
-        
+
         step = Step(
             step_id="test-2",
             step_type=StepType.MESSAGE,
             message=message,
             tool_call=tool_call,
-            thinking="Some internal reasoning"
+            thinking="Some internal reasoning",
         )
-        
+
         assert step.has_message_content()
         assert step.has_tool_content()
         assert not step.has_event_content()
@@ -56,37 +60,22 @@ class TestEnhancedSteps:
     def test_message_step_tool_call_parts(self):
         """Test MessageStep with tool call parts."""
         # Create tool call and result
-        tool_call = ToolCall(
-            call_id="call-123",
-            name="search_web",
-            arguments={"query": "latest AI news"}
-        )
-        tool_result = ToolCallResult(
-            call_id="call-123",
-            success=True,
-            output="Found 10 articles about AI"
-        )
-        
+        tool_call = ToolCall(call_id="call-123", name="search_web", arguments={"query": "latest AI news"})
+        tool_result = ToolCallResult(call_id="call-123", success=True, output="Found 10 articles about AI")
+
         # Create message with tool call parts
-        message = Message(
-            messageId="msg-with-tools",
-            role="agent",
-            parts=[]
-        )
+        message = Message(messageId="msg-with-tools", role="agent", parts=[])
         message.add_text_part("I'll search for that information.")
         message.add_tool_call_part(tool_call)
         message.add_tool_result_part(tool_result, tool_call.name)
         message.add_text_part("Here are the results I found.")
 
         # Create message step
-        step = MessageStep(
-            step_id="msg-step-1",
-            message=message
-        )
+        step = MessageStep(step_id="msg-step-1", message=message)
 
         assert step.has_message_content()
         assert len(step.message.parts) == 4
-        
+
         # Check part types
         assert step.message.parts[0].kind == "text"
         assert step.message.parts[1].kind == "tool-use"
@@ -98,31 +87,22 @@ class TestEnhancedSteps:
     def test_tool_call_step_enhanced(self):
         """Test enhanced ToolCallStep with result handling."""
         tool_call = ToolCall(
-            call_id="call-456",
-            name="write_file",
-            arguments={"path": "test.txt", "content": "Hello world"}
+            call_id="call-456", name="write_file", arguments={"path": "test.txt", "content": "Hello world"}
         )
-        
-        step = ToolCallStep(
-            step_id="tool-step-1",
-            tool_call=tool_call
-        )
-        
+
+        step = ToolCallStep(step_id="tool-step-1", tool_call=tool_call)
+
         assert step.has_tool_content()
         assert step.tool_call_result is None
         assert step.success is True  # Default
-        
+
         # Add result
-        result = ToolCallResult(
-            call_id="call-456",
-            success=True,
-            output="File written successfully"
-        )
+        result = ToolCallResult(call_id="call-456", success=True, output="File written successfully")
         step.add_result(result)
-        
+
         assert step.tool_call_result is not None
         assert step.success is True
-        
+
         # Test conversion to message parts
         call_part, result_part = step.to_message_parts()
         assert isinstance(call_part, ToolUsePart)
@@ -136,56 +116,36 @@ class TestEnhancedSteps:
         """Test EventStep with A2A vs internal events."""
         # A2A event
         a2a_event = TaskStatusUpdateEvent(
-            contextId="ctx-1",
-            taskId="task-1",
-            status=TaskStatus(state=TaskState.working),
-            final=False
+            contextId="ctx-1", taskId="task-1", status=TaskStatus(state=TaskState.working), final=False
         )
-        
-        a2a_step = EventStep(
-            step_id="event-step-1",
-            event=a2a_event,
-            event_type=EventType.TASK_STATUS_UPDATE
-        )
-        
+
+        a2a_step = EventStep(step_id="event-step-1", event=a2a_event, event_type=EventType.TASK_STATUS_UPDATE)
+
         assert a2a_step.has_event_content()
         assert a2a_step.is_a2a_event()
         assert not a2a_step.is_internal_event()
-        
+
         # Internal event
-        internal_event = RunEvent(
-            event_type="custom_event",
-            data={"custom": "data"}
-        )
-        
-        internal_step = EventStep(
-            step_id="event-step-2",
-            event=internal_event,
-            event_type=EventType.THINK
-        )
-        
+        internal_event = RunEvent(event_type="custom_event", data={"custom": "data"})
+
+        internal_step = EventStep(step_id="event-step-2", event=internal_event, event_type=EventType.THINK)
+
         assert internal_step.has_event_content()
         assert not internal_step.is_a2a_event()
         assert internal_step.is_internal_event()
 
     def test_finish_step_completion_event(self):
         """Test FinishStep with completion event creation."""
-        step = FinishStep(
-            step_id="finish-1",
-            reason="Task completed successfully"
-        )
-        
+        step = FinishStep(step_id="finish-1", reason="Task completed successfully")
+
         assert step.has_message_content()
         assert step.message is not None
         assert len(step.message.parts) == 1
         assert step.message.parts[0].text == "Task completed successfully"
-        
+
         # Create completion event
-        completion_event = step.create_completion_event(
-            task_id="task-123",
-            context_id="ctx-456"
-        )
-        
+        completion_event = step.create_completion_event(task_id="task-123", context_id="ctx-456")
+
         assert isinstance(completion_event, TaskStatusUpdateEvent)
         assert completion_event.taskId == "task-123"
         assert completion_event.contextId == "ctx-456"
@@ -194,29 +154,20 @@ class TestEnhancedSteps:
 
     async def test_message_step_streaming(self):
         """Test MessageStep streaming functionality."""
-        message = Message(
-            messageId="streaming-msg",
-            role="agent",
-            parts=[]
-        )
+        message = Message(messageId="streaming-msg", role="agent", parts=[])
         message.add_text_part(
-            "This is a longer text that will be streamed in chunks to demonstrate " +
-            "the streaming functionality."
+            "This is a longer text that will be streamed in chunks to demonstrate " + "the streaming functionality."
         )
-        
-        step = MessageStep(
-            step_id="stream-step-1",
-            message=message,
-            is_streaming=True
-        )
-        
+
+        step = MessageStep(step_id="stream-step-1", message=message, is_streaming=True)
+
         chunks = []
         async for chunk in step.stream_content():
             chunks.append(chunk)
-        
+
         # Should have multiple chunks
         assert len(chunks) > 1
-        
+
         # Recombined chunks should equal original text
         full_text = "".join(chunks)
         assert full_text == message.parts[0].text
@@ -225,29 +176,21 @@ class TestEnhancedSteps:
         """Test ToolUsePart validation for both calls and results."""
         # Test tool call
         tool_call_part = ToolUsePart(
-            type='call',
-            id="call-789",
-            name="calculate",
-            input={"x": 5, "y": 3},
-            metadata={"priority": "high"}
+            type="call", id="call-789", name="calculate", input={"x": 5, "y": 3}, metadata={"priority": "high"}
         )
-        
+
         assert tool_call_part.kind == "tool-use"
         assert tool_call_part.type == "call"
         assert tool_call_part.id == "call-789"
         assert tool_call_part.name == "calculate"
         assert tool_call_part.input == {"x": 5, "y": 3}
         assert tool_call_part.metadata["priority"] == "high"
-        
+
         # Test tool result
         result_part = ToolUsePart(
-            type='result',
-            id="call-789",
-            name="calculate",
-            output="8",
-            metadata={"execution_time": 0.05}
+            type="result", id="call-789", name="calculate", output="8", metadata={"execution_time": 0.05}
         )
-        
+
         assert result_part.kind == "tool-use"
         assert result_part.type == "result"
         assert result_part.id == "call-789"
@@ -257,35 +200,23 @@ class TestEnhancedSteps:
 
     def test_comprehensive_message_with_all_parts(self):
         """Test message with all types of parts including tool calls."""
-        message = Message(
-            messageId="comprehensive-msg",
-            role="agent",
-            parts=[]
-        )
-        
+        message = Message(messageId="comprehensive-msg", role="agent", parts=[])
+
         # Add various part types
         message.add_text_part("Let me help you with that task.")
-        
-        message.add_data_part({
-            "task_info": {"id": "123", "type": "analysis"}
-        })
-        
-        tool_call = ToolCall(
-            call_id="call-999",
-            name="analyze_data",
-            arguments={"dataset": "user_data.csv"}
-        )
+
+        message.add_data_part({"task_info": {"id": "123", "type": "analysis"}})
+
+        tool_call = ToolCall(call_id="call-999", name="analyze_data", arguments={"dataset": "user_data.csv"})
         message.add_tool_call_part(tool_call)
-        
+
         tool_result = ToolCallResult(
-            call_id="call-999",
-            success=True,
-            output="Analysis complete: 1000 records processed"
+            call_id="call-999", success=True, output="Analysis complete: 1000 records processed"
         )
         message.add_tool_result_part(tool_result, "analyze_data")
-        
+
         message.add_text_part("Analysis is complete! Here are the results.")
-        
+
         # Verify all parts
         assert len(message.parts) == 5
         assert message.parts[0].kind == "text"
@@ -295,13 +226,10 @@ class TestEnhancedSteps:
         assert message.parts[3].kind == "tool-use"
         assert message.parts[3].type == "result"
         assert message.parts[4].kind == "text"
-        
+
         # Create step with this comprehensive message
-        step = MessageStep(
-            step_id="comprehensive-step",
-            message=message
-        )
-        
+        step = MessageStep(step_id="comprehensive-step", message=message)
+
         content_types = step.get_content_types()
         assert "message" in content_types
-        assert step.has_message_content() 
+        assert step.has_message_content()

--- a/tests/agent/test_search_agent.py
+++ b/tests/agent/test_search_agent.py
@@ -1,0 +1,85 @@
+import pytest
+
+from codin.agent.search_agent import SearchAgent
+from codin.agent.base import Planner
+from codin.agent.types import AgentRunInput, Message, TextPart, Role, RunConfig, State
+from codin.model.base import BaseLLM
+from codin.tool.base import Tool
+from codin.artifact.base import ArtifactService
+
+# Ensure pydantic models referencing Tool are initialized
+State.model_rebuild(force=True, _types_namespace={
+    'Tool': Tool,
+    'ArtifactService': ArtifactService,
+    'Message': Message,
+})
+
+class DummyPlanner(Planner):
+    def __init__(self):
+        self.calls = 0
+
+    async def next(self, state):
+        self.calls += 1
+        if False:
+            yield  # pragma: no cover
+
+    async def reset(self, state):
+        pass
+
+class DummyMemory:
+    async def add_message(self, message: Message) -> None:
+        pass
+
+    async def get_history(self, limit: int = 50, query: str | None = None) -> list[Message]:
+        return []
+
+    async def set_chunk_builder(self, chunk_builder):
+        pass
+
+    async def build_chunk(self, start_index: int | None = None, end_index: int | None = None) -> int:
+        return 0
+
+    async def search_chunk(self, session_id: str, query: str, limit: int = 5) -> list:
+        return []
+
+class MockLLM(BaseLLM):
+    @classmethod
+    def supported_models(cls):
+        return ["mock-llm"]
+
+    async def prepare(self):
+        pass
+
+    async def generate(self, *args, **kwargs):
+        return "ok"
+
+    async def generate_with_tools(self, *args, **kwargs):
+        return {"content": "ok", "tool_calls": []}
+
+@pytest.mark.asyncio
+async def test_search_agent_runs_multiple_planner_calls():
+    planner = DummyPlanner()
+    llm = MockLLM("mock-llm")
+    agent = SearchAgent(
+        name="search",
+        description="d",
+        planner=planner,
+        llm=llm,
+        memory=DummyMemory(),
+        default_config=RunConfig(turn_budget=1),
+        search_width=1,
+    )
+
+    msg = Message(messageId="u1", role=Role.user, parts=[TextPart(text="hi")], contextId="ctx", kind="message")
+    input_data = AgentRunInput(
+        message=msg,
+        options={"config": RunConfig(turn_budget=1)},
+        metadata={"badgers": 3},
+    )
+
+    outputs = [o async for o in agent.run(input_data)]
+
+    assert outputs == []
+    assert planner.calls == 3
+
+    await agent.cleanup()

--- a/tests/memory/test_memory_system.py
+++ b/tests/memory/test_memory_system.py
@@ -5,12 +5,12 @@ import uuid
 from datetime import datetime
 
 from codin.memory.base import MemoryService, MemMemoryService, MemoryChunk, ChunkType
-from a2a.types import Message, TextPart, Role
+from codin.agent.types import Message, TextPart, Role
 
 
 class TestMemoryChunk:
     """Test MemoryChunk functionality."""
-    
+
     def test_init(self):
         """Test MemoryChunk initialization."""
         entities = {"file1": "main.py", "person1": "Alice"}
@@ -24,9 +24,9 @@ class TestMemoryChunk:
             start_message_id="msg1",
             end_message_id="msg5",
             created_at=datetime.now(),
-            message_count=5
+            message_count=5,
         )
-        
+
         assert chunk.doc_id == "doc-123"
         assert chunk.chunk_id == "test-chunk"
         assert chunk.session_id == "session1"
@@ -35,7 +35,7 @@ class TestMemoryChunk:
         assert chunk.message_count == 5
         assert chunk.get_content_dict() == entities
         assert "file1: main.py" in chunk.content
-    
+
     def test_to_message(self):
         """Test converting MemoryChunk to Message."""
         chunk = MemoryChunk(
@@ -48,29 +48,29 @@ class TestMemoryChunk:
             start_message_id="msg1",
             end_message_id="msg5",
             created_at=datetime.now(),
-            message_count=3
+            message_count=3,
         )
-        
+
         message = chunk.to_message()
-        
+
         assert message.role == Role.user
         assert message.contextId == "session1"
         assert message.kind == "message"
-        
+
         # Extract text content
         first_part = message.parts[0]
-        if hasattr(first_part, 'root') and hasattr(first_part.root, 'text'):
+        if hasattr(first_part, "root") and hasattr(first_part.root, "text"):
             text_content = first_part.root.text
-        elif hasattr(first_part, 'text'):
+        elif hasattr(first_part, "text"):
             text_content = first_part.text
         else:
             text_content = str(first_part)
-        
+
         assert "MEMORY SUMMARY" in text_content
         assert "3 messages" in text_content
         assert "Python Discussion" in text_content
         assert "Python" in text_content
-        
+
         # Check metadata
         assert message.metadata["is_memory_chunk"] is True
         assert message.metadata["doc_id"] == "doc-123"
@@ -81,12 +81,12 @@ class TestMemoryChunk:
 
 class TestInMemoryStore:
     """Test InMemoryStore implementation."""
-    
+
     @pytest.fixture
     def memory_store(self):
         """Create a fresh InMemoryStore for each test."""
         return MemMemoryService()
-    
+
     @pytest.fixture
     def sample_messages(self):
         """Create sample messages for testing."""
@@ -96,71 +96,71 @@ class TestInMemoryStore:
                 role=Role.user,
                 parts=[TextPart(text="Hello, how are you?")],
                 contextId="session1",
-                kind="message"
+                kind="message",
             ),
             Message(
                 messageId="msg2",
                 role=Role.agent,
                 parts=[TextPart(text="I'm doing well, thank you! How can I help you today?")],
-                contextId="session1", 
-                kind="message"
+                contextId="session1",
+                kind="message",
             ),
             Message(
                 messageId="msg3",
                 role=Role.user,
                 parts=[TextPart(text="Can you help me write a Python function?")],
                 contextId="session1",
-                kind="message"
-            )
+                kind="message",
+            ),
         ]
-    
+
     @pytest.mark.asyncio
     async def test_add_message(self, memory_store, sample_messages):
         """Test adding messages to memory."""
         for msg in sample_messages:
             await memory_store.add_message(msg)
-        
+
         # Check internal storage
         assert "session1" in memory_store._messages
         assert len(memory_store._messages["session1"]) == 3
-    
+
     @pytest.mark.asyncio
     async def test_get_history(self, memory_store, sample_messages):
         """Test retrieving conversation history."""
         # Add messages
         for msg in sample_messages:
             await memory_store.add_message(msg)
-        
+
         # Get history
         history = await memory_store.get_history("session1", limit=10)
-        
+
         assert len(history) == 3
         assert history[0].messageId == "msg1"
         assert history[1].messageId == "msg2"
         assert history[2].messageId == "msg3"
-    
+
     @pytest.mark.asyncio
     async def test_get_history_with_limit(self, memory_store, sample_messages):
         """Test history retrieval with limit."""
         # Add messages
         for msg in sample_messages:
             await memory_store.add_message(msg)
-        
+
         # Get limited history
         history = await memory_store.get_history("session1", limit=2)
-        
+
         assert len(history) == 2
         assert history[0].messageId == "msg2"  # Last 2 messages
         assert history[1].messageId == "msg3"
-    
+
     @pytest.mark.asyncio
     async def test_create_memory_chunk(self, memory_store, sample_messages):
         """Test creating memory chunks."""
         chunks = await memory_store.create_memory_chunk("session1", sample_messages)
-        
+
         assert isinstance(chunks, list)
         assert len(chunks) >= 1  # At least summary chunk
-        
+
         # Check summary chunk
         summary_chunk = chunks[0]
         assert isinstance(summary_chunk, MemoryChunk)
@@ -171,171 +171,167 @@ class TestInMemoryStore:
         assert summary_chunk.message_count == 3
         assert len(summary_chunk.content) > 0
         assert "Conversation Summary" in summary_chunk.title
-    
+
     @pytest.mark.asyncio
     async def test_create_memory_chunk_empty_list(self, memory_store):
         """Test creating memory chunk with empty message list."""
         with pytest.raises(ValueError, match="Cannot create memory chunk from empty message list"):
             await memory_store.create_memory_chunk("session1", [])
-    
+
     @pytest.mark.asyncio
     async def test_search_memory_chunks(self, memory_store, sample_messages):
         """Test searching memory chunks."""
         # Create chunks
         chunks = await memory_store.create_memory_chunk("session1", sample_messages)
-        
+
         # Search for relevant chunks
         results = await memory_store.search_memory_chunks("session1", "python", limit=5)
-        
+
         # Should find chunks since they contain "Python"
         assert len(results) >= 0  # May be 0 if search doesn't match
-    
+
     @pytest.mark.asyncio
     async def test_get_history_with_query(self, memory_store, sample_messages):
         """Test getting history with search query."""
         # Add messages and create chunks
         for msg in sample_messages:
             await memory_store.add_message(msg)
-        
+
         chunks = await memory_store.create_memory_chunk("session1", sample_messages[:2])
-        
+
         # Get history with query
         history = await memory_store.get_history("session1", limit=10, query="hello")
-        
+
         # Should include recent messages, and potentially memory chunks
         assert len(history) >= 3  # At least the 3 original messages
-    
+
     @pytest.mark.asyncio
     async def test_compress_old_messages(self, memory_store, sample_messages):
         """Test compressing old messages."""
         # Add messages
         for msg in sample_messages:
             await memory_store.add_message(msg)
-        
+
         # Compress keeping only 1 recent message
-        chunk_groups_created = await memory_store.compress_old_messages(
-            "session1", 
-            keep_recent=1, 
-            chunk_size=2
-        )
-        
+        chunk_groups_created = await memory_store.compress_old_messages("session1", keep_recent=1, chunk_size=2)
+
         assert chunk_groups_created == 1  # Should create 1 chunk group from 2 old messages
-        
+
         # Check that only 1 recent message remains
         remaining_messages = memory_store._messages["session1"]
         assert len(remaining_messages) == 1
         assert remaining_messages[0].messageId == "msg3"  # Most recent
-        
+
         # Check that chunks were created (at least summary chunk)
         chunks = memory_store._chunks["session1"]
         assert len(chunks) >= 1
-    
+
     def test_simple_summarize(self, memory_store):
         """Test simple text summarization."""
         text = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"
         summary = memory_store._simple_summarize(text)
-        
+
         assert "Line 1" in summary
         assert "Line 5" in summary
         assert "..." in summary
-    
+
     def test_simple_summarize_short_text(self, memory_store):
         """Test simple summarization with short text."""
         text = "Short text"
         summary = memory_store._simple_summarize(text)
-        
+
         assert summary == text  # Should return unchanged
 
 
 class TestMemorySystemIntegration:
     """Test memory system integration scenarios."""
-    
+
     @pytest.mark.asyncio
     async def test_multiple_sessions(self):
         """Test handling multiple sessions."""
         memory = MemMemoryService()
-        
+
         # Add messages to different sessions
         msg1 = Message(
             messageId="msg1",
             role=Role.user,
             parts=[TextPart(text="Session 1 message")],
             contextId="session1",
-            kind="message"
+            kind="message",
         )
-        
+
         msg2 = Message(
             messageId="msg2",
             role=Role.user,
             parts=[TextPart(text="Session 2 message")],
             contextId="session2",
-            kind="message"
+            kind="message",
         )
-        
+
         await memory.add_message(msg1)
         await memory.add_message(msg2)
-        
+
         # Get history for each session
         history1 = await memory.get_history("session1")
         history2 = await memory.get_history("session2")
-        
+
         assert len(history1) == 1
         assert len(history2) == 1
         assert history1[0].messageId == "msg1"
         assert history2[0].messageId == "msg2"
-    
+
     @pytest.mark.asyncio
     async def test_llm_summarizer_integration(self):
         """Test integration with LLM summarizer."""
         memory = MemMemoryService()
-        
+
         messages = [
             Message(
                 messageId="msg1",
                 role=Role.user,
                 parts=[TextPart(text="Create a Python file called main.py")],
                 contextId="session1",
-                kind="message"
+                kind="message",
             ),
             Message(
                 messageId="msg2",
                 role=Role.agent,
                 parts=[TextPart(text="I'll create main.py for you with a simple structure.")],
                 contextId="session1",
-                kind="message"
-            )
+                kind="message",
+            ),
         ]
-        
+
         # Mock LLM summarizer
         async def mock_summarizer(text: str) -> dict:
             return {
                 "summary": "User requested creation of main.py file",
                 "entities": {"file": "main.py", "language": "Python"},
-                "id_mappings": {"file1": "main.py"}
+                "id_mappings": {"file1": "main.py"},
             }
-        
+
         chunks = await memory.create_memory_chunk("session1", messages, mock_summarizer)
-        
+
         # Find summary chunk
         summary_chunk = next(c for c in chunks if c.chunk_type == ChunkType.MEMORY_SUMMARY)
         assert summary_chunk.content == "User requested creation of main.py file"
-        
+
         # Find entities chunk
         entities_chunk = next(c for c in chunks if c.chunk_type == ChunkType.MEMORY_ENTITY)
         entities_dict = entities_chunk.get_content_dict()
         assert entities_dict["file"] == "main.py"
         assert entities_dict["language"] == "Python"
-        
+
         # Find ID mappings chunk
         mappings_chunk = next(c for c in chunks if c.chunk_type == ChunkType.MEMORY_ID_MAPPING)
         mappings_dict = mappings_chunk.get_content_dict()
         assert mappings_dict["file1"] == "main.py"
-    
+
     @pytest.mark.asyncio
     async def test_search_with_title_weighting(self):
         """Test search functionality with title weighting."""
         memory = MemMemoryService()
-        
+
         # Create chunks with different titles
         chunk1 = MemoryChunk(
             doc_id="doc1",
@@ -344,55 +340,51 @@ class TestMemorySystemIntegration:
             chunk_type=ChunkType.MEMORY_SUMMARY,
             content="Discussion about Python programming",
             title="Python Tutorial",
-            message_count=5
+            message_count=5,
         )
-        
+
         chunk2 = MemoryChunk(
-            doc_id="doc2", 
+            doc_id="doc2",
             chunk_id="chunk2",
             session_id="session1",
             chunk_type=ChunkType.MEMORY_ENTITY,
             content="file: script.py\nlanguage: JavaScript",
             title="JavaScript Project",
-            message_count=3
+            message_count=3,
         )
-        
+
         # Store chunks manually
         memory._chunks["session1"] = [chunk1, chunk2]
-        
+
         # Search for "Python" - should rank chunk1 higher due to title match
         results = await memory.search_chunk("session1", "python", limit=5)
-        
+
         assert len(results) >= 1
         # First result should be chunk1 due to title match
         assert results[0].chunk_id == "chunk1"
         assert results[0].title == "Python Tutorial"
-    
+
     @pytest.mark.asyncio
     async def test_dict_content_searchable_string(self):
         """Test that dictionary content is properly converted to searchable string."""
-        entities = {
-            "file": "main.py",
-            "language": "Python",
-            "nested": {"type": "script", "version": "3.9"}
-        }
-        
+        entities = {"file": "main.py", "language": "Python", "nested": {"type": "script", "version": "3.9"}}
+
         chunk = MemoryChunk(
             doc_id="doc1",
-            chunk_id="chunk1", 
+            chunk_id="chunk1",
             session_id="session1",
             chunk_type=ChunkType.MEMORY_ENTITY,
             content=entities,
-            title="Test Entities"
+            title="Test Entities",
         )
-        
+
         searchable_content = chunk.get_content_string()
-        
+
         # Check that all keys and values are searchable
         assert "file: main.py" in searchable_content
         assert "language: Python" in searchable_content
         assert "nested.type: script" in searchable_content
         assert "nested.version: 3.9" in searchable_content
-        
+
         # Original dict should be preserved
-        assert chunk.get_content_dict() == entities 
+        assert chunk.get_content_dict() == entities

--- a/tests/test_message_utils.py
+++ b/tests/test_message_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from a2a.types import Message, TextPart, Role
+from codin.agent.types import Message, TextPart, Role
 from codin.agent.types import ToolCallResult
 from codin.utils.message import (
     extract_text_from_message,

--- a/tests/tool/test_executor.py
+++ b/tests/tool/test_executor.py
@@ -6,21 +6,16 @@ import typing as _t
 from codin.tool.base import Tool, ToolContext
 from codin.tool.executor import ToolExecutor
 from codin.tool.registry import ToolRegistry
-from a2a.types import TextPart
+from codin.agent.types import TextPart
 
 
 class AsyncGeneratorTestTool(Tool):
     """Test tool that returns an async generator."""
 
     def __init__(self):
-        super().__init__(
-            name="async_generator_test",
-            description="Test tool that returns an async generator"
-        )
+        super().__init__(name="async_generator_test", description="Test tool that returns an async generator")
 
-    async def run(
-        self, args: dict[str, _t.Any], context: ToolContext
-    ) -> _t.AsyncGenerator[str, None]:
+    async def run(self, args: dict[str, _t.Any], context: ToolContext) -> _t.AsyncGenerator[str, None]:
         """Return an async generator."""
         for i in range(3):
             yield f"item_{i}"
@@ -30,10 +25,7 @@ class RegularTestTool(Tool):
     """Test tool that returns a regular result."""
 
     def __init__(self):
-        super().__init__(
-            name="regular_test",
-            description="Test tool that returns a regular result"
-        )
+        super().__init__(name="regular_test", description="Test tool that returns a regular result")
 
     async def run(self, args: dict[str, _t.Any], context: ToolContext) -> str:
         """Return a regular string result."""
@@ -68,7 +60,7 @@ def executor(registry):
 async def test_executor_with_async_generator(executor, mock_context):
     """Test that executor properly handles tools that return async generators."""
     result = await executor.execute("async_generator_test", {}, mock_context)
-    
+
     # Should return a list of items from the async generator
     assert isinstance(result, list)
     assert len(result) == 3
@@ -79,7 +71,7 @@ async def test_executor_with_async_generator(executor, mock_context):
 async def test_executor_with_regular_tool(executor, mock_context):
     """Test that executor properly handles tools that return regular results."""
     result = await executor.execute("regular_test", {}, mock_context)
-    
+
     # Should return the string result converted to TextPart
     assert isinstance(result, TextPart)
     assert result.text == "regular_result"
@@ -88,24 +80,19 @@ async def test_executor_with_regular_tool(executor, mock_context):
 @pytest.mark.asyncio
 async def test_executor_with_single_item_async_generator(executor, mock_context):
     """Test executor with async generator that yields single item."""
-    
+
     class SingleItemAsyncGeneratorTool(Tool):
         def __init__(self):
-            super().__init__(
-                name="single_item_test",
-                description="Test tool that returns single item async generator"
-            )
+            super().__init__(name="single_item_test", description="Test tool that returns single item async generator")
 
-        async def run(
-            self, args: dict[str, _t.Any], context: ToolContext
-        ) -> _t.AsyncGenerator[str, None]:
+        async def run(self, args: dict[str, _t.Any], context: ToolContext) -> _t.AsyncGenerator[str, None]:
             yield "single_item"
 
     # Register the tool
     executor.registry.register_tool(SingleItemAsyncGeneratorTool())
-    
+
     result = await executor.execute("single_item_test", {}, mock_context)
-    
+
     # Should return the single item converted to TextPart
     assert isinstance(result, TextPart)
-    assert result.text == "single_item" 
+    assert result.text == "single_item"


### PR DESCRIPTION
## Summary
- let `BaseAgent` include input metadata in State
- add `SearchAgent` with search algorithm using any `Planner`
- implement minimal in-tree `a2a.types` for tests
- update search agent test to provide badgers via metadata
- merge `src/a2a/types.py` into `src/codin/agent/types.py` and update imports

## Testing
- `pytest tests/agent/test_search_agent.py::test_search_agent_runs_multiple_planner_calls -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e5440f808320a2c181361a9f6d34