### PR TITLE
Add SWE benchmark runner with CLI command

### DIFF
--- a/src/codin/actor/supervisor.py
+++ b/src/codin/actor/supervisor.py
@@ -11,6 +11,11 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+# Provide a runtime definition for ``Agent`` so Pydantic can resolve the
+# forward reference on import. This avoids the need for tests to patch in the
+# ``Agent`` type before calling ``ActorInfo.model_rebuild``.
+from ..agent.base_agent import BaseAgent as Agent
+
 if _t.TYPE_CHECKING:
     from ..agent.base import Agent
 

--- a/src/codin/cli/commands.py
+++ b/src/codin/cli/commands.py
@@ -658,6 +658,62 @@ def debug_sandbox_cmd(full_auto: bool, permissions: tuple[str, ...], command: tu
     asyncio.run(_run())
 
 
+@cli.command("swe-benchmark")
+@click.option("--dataset", default="SWE-bench/SWE-bench_Lite", help="Dataset name or path")
+@click.option("--split", default="test", help="Dataset split")
+@click.option("--predictions", "predictions_path", required=True, type=click.Path(exists=True), help="Path to predictions file")
+@click.option("--instance-id", "instance_ids", multiple=True, help="Instance IDs to run")
+@click.option("--run-id", default=None, help="Run identifier")
+@click.option("--report-dir", default=".", type=click.Path(), help="Directory for reports")
+@click.option("--max-workers", default=4, type=int, help="Maximum worker processes")
+@click.option("--force-rebuild", is_flag=True, help="Force rebuild images")
+@click.option("--cache-level", default="env", help="Image cache level")
+@click.option("--clean", is_flag=True, help="Clean images above cache level")
+@click.option("--open-file-limit", default=4096, type=int, help="Open file descriptor limit")
+@click.option("--timeout", default=1800, type=int, help="Per-instance timeout in seconds")
+@click.option("--namespace", default="swebench", help="Docker namespace")
+@click.option("--rewrite-reports", is_flag=True, help="Only rewrite existing reports")
+@click.option("--modal", is_flag=True, help="Run using Modal")
+def swe_benchmark_cmd(
+    dataset: str,
+    split: str,
+    predictions_path: str,
+    instance_ids: tuple[str, ...],
+    run_id: str | None,
+    report_dir: str,
+    max_workers: int,
+    force_rebuild: bool,
+    cache_level: str,
+    clean: bool,
+    open_file_limit: int,
+    timeout: int,
+    namespace: str | None,
+    rewrite_reports: bool,
+    modal: bool,
+) -> None:
+    """Run the SWE-bench evaluation harness."""
+
+    from codin.evaluate import run_swe_benchmark
+
+    run_swe_benchmark(
+        dataset_name=dataset,
+        split=split,
+        instance_ids=list(instance_ids),
+        predictions_path=predictions_path,
+        max_workers=max_workers,
+        force_rebuild=force_rebuild,
+        cache_level=cache_level,
+        clean=clean,
+        open_file_limit=open_file_limit,
+        run_id=run_id,
+        timeout=timeout,
+        namespace=namespace,
+        rewrite_reports=rewrite_reports,
+        modal=modal,
+        report_dir=report_dir,
+    )
+
+
 def main() -> None:
     """Main entry point for the CLI."""
     import atexit

--- a/src/codin/evaluate/__init__.py
+++ b/src/codin/evaluate/__init__.py
@@ -1,0 +1,5 @@
+"""Evaluation utilities for running benchmarks."""
+
+from .swe import run_swe_benchmark
+
+__all__ = ["run_swe_benchmark"]

--- a/src/codin/evaluate/swe.py
+++ b/src/codin/evaluate/swe.py
@@ -1,0 +1,59 @@
+"""Helpers for running the SWE-bench evaluation harness."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from swebench.harness.run_evaluation import main as swe_run_main
+
+__all__ = ["run_swe_benchmark"]
+
+
+def run_swe_benchmark(
+    *,
+    dataset_name: str = "SWE-bench/SWE-bench_Lite",
+    split: str = "test",
+    instance_ids: Iterable[str] | None = None,
+    predictions_path: str,
+    max_workers: int = 4,
+    force_rebuild: bool = False,
+    cache_level: str = "env",
+    clean: bool = False,
+    open_file_limit: int = 4096,
+    run_id: str | None = None,
+    timeout: int = 1800,
+    namespace: str | None = "swebench",
+    rewrite_reports: bool = False,
+    modal: bool = False,
+    instance_image_tag: str = "latest",
+    report_dir: str = ".",
+) -> dict:
+    """Run the SWE-bench evaluation harness.
+
+    This is a thin wrapper around :func:`swebench.harness.run_evaluation.main`.
+    All arguments map directly to the underlying harness.
+    """
+
+    if run_id is None:
+        run_id = datetime.now().strftime("%Y%m%d-%H%M%S")
+    ids = list(instance_ids) if instance_ids is not None else []
+    return swe_run_main(
+        dataset_name=dataset_name,
+        split=split,
+        instance_ids=ids,
+        predictions_path=predictions_path,
+        max_workers=max_workers,
+        force_rebuild=force_rebuild,
+        cache_level=cache_level,
+        clean=clean,
+        open_file_limit=open_file_limit,
+        run_id=run_id,
+        timeout=timeout,
+        namespace=namespace,
+        rewrite_reports=rewrite_reports,
+        modal=modal,
+        instance_image_tag=instance_image_tag,
+        report_dir=report_dir,
+    )
+


### PR DESCRIPTION
## Summary
- add `evaluate` package with SWE-bench support
- expose benchmark via `swe-benchmark` CLI command
- fix sandbox debug command indentation
- ensure `ActorInfo` resolves `Agent` at import time

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844e5bf07988320b5ad3a615eb06123