### PR TITLE
Implement sandbox enhancements

### DIFF
--- a/src/codin/sandbox/codex.py
+++ b/src/codin/sandbox/codex.py
@@ -4,20 +4,31 @@ This module provides a sandbox implementation that integrates with
 the Codex CLI for secure code execution and file operations.
 """
 
+import platform
+import shutil
 import typing as _t
 from pathlib import Path
+import logging
 
-from .base import ExecResult, Sandbox, ShellEnvironmentPolicy
+from .local import LocalSandbox
+
+from .base import ExecResult, ShellEnvironmentPolicy
+
+logger = logging.getLogger(__name__)
 
 __all__ = ['CodexSandbox']
 
 
-class CodexSandbox(Sandbox):
-    """Codex CLI sandbox wrapper (TODO)."""
+class CodexSandbox(LocalSandbox):
+    """Sandbox that routes commands through the Codex CLI sandbox helpers."""
 
-    def __init__(self, *, env_policy: ShellEnvironmentPolicy | None = None, **_kwargs):
-        super().__init__(env_policy=env_policy)
-        raise NotImplementedError('CodexSandbox is not yet implemented. Contributions welcome!')
+    def __init__(self, workdir: str | None = None, *, codex_cmd: str = 'codex', env_policy: ShellEnvironmentPolicy | None = None, **_kwargs):
+        super().__init__(workdir=workdir, env_policy=env_policy)
+        self._codex_cmd = codex_cmd
+        self._codex_available = shutil.which(codex_cmd) is not None
+        self._cmd_prefix = ['debug', 'landlock'] if platform.system().lower() == 'linux' else ['debug', 'seatbelt']
+        if not self._codex_available:
+            logger.warning('Codex CLI not found – falling back to LocalSandbox behaviour')
 
     async def _up(self) -> None:
         """Set up the Codex sandbox."""
@@ -34,7 +45,13 @@ class CodexSandbox(Sandbox):
         env: dict[str, str] | None = None,
     ) -> ExecResult:
         """Execute a command in the Codex sandbox."""
-        raise NotImplementedError('CodexSandbox is not yet implemented')
+        if not self._codex_available:
+            # Fallback to LocalSandbox behaviour
+            return await super().run_cmd(cmd, cwd=cwd, timeout=timeout, env=env)
+
+        cmd_list = cmd if isinstance(cmd, list) or isinstance(cmd, tuple) else [cmd]
+        full_cmd = [self._codex_cmd, *self._cmd_prefix, '--', *cmd_list]
+        return await super().run_cmd(full_cmd, cwd=cwd, timeout=timeout, env=env)
 
     async def run_code(
         self,
@@ -47,16 +64,23 @@ class CodexSandbox(Sandbox):
         env: dict[str, str] | None = None,
     ) -> ExecResult:
         """Execute code in the Codex sandbox."""
-        raise NotImplementedError('CodexSandbox is not yet implemented')
+        return await super().run_code(
+            code,
+            file_path=file_path,
+            language=language,
+            dependencies=dependencies,
+            timeout=timeout,
+            env=env,
+        )
 
     async def list_files(self, path: str = '.') -> list[str]:
         """List files in the Codex sandbox."""
-        raise NotImplementedError('CodexSandbox is not yet implemented')
+        return await super().list_files(path)
 
     async def read_file(self, path: str) -> str:
         """Read a file from the Codex sandbox."""
-        raise NotImplementedError('CodexSandbox is not yet implemented')
+        return await super().read_file(path)
 
     async def write_file(self, path: str, content: str) -> None:
         """Write content to a file in the Codex sandbox."""
-        raise NotImplementedError('CodexSandbox is not yet implemented')
+        await super().write_file(path, content)

--- a/tests/sandbox/test_local_sandbox.py
+++ b/tests/sandbox/test_local_sandbox.py
@@ -1,0 +1,14 @@
+import pytest
+from codin.sandbox.local import LocalSandbox
+
+@pytest.mark.asyncio
+async def test_run_c_code(tmp_path):
+    sandbox = LocalSandbox(workdir=str(tmp_path))
+    await sandbox.up()
+    try:
+        code = "#include <stdio.h>\nint main(){printf(\"hi\\n\");return 0;}"
+        result = await sandbox.run_code(code, language='c')
+        assert result.exit_code == 0
+        assert 'hi' in result.stdout
+    finally:
+        await sandbox.down()


### PR DESCRIPTION
## Summary
- remember last file edits and implement a working `reapply` tool
- add C/C++ support to `LocalSandbox.run_code`
- implement `CodexSandbox` using Codex CLI if available
- load tools from filesystem in `ToolRegistry`
- update tests and add new test for running C code

## Testing
- `pytest -q tests/sandbox/test_local_sandbox.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68452add077483209639e17708ea7178