### PR TITLE
Fix imports and module aliasing

### DIFF
--- a/src/codin/__init__.py
+++ b/src/codin/__init__.py
@@ -4,7 +4,12 @@ This package exposes high-level helpers for building agents, tools and runtimes
 that interoperate via the A2A protocol.
 """
 
+import sys as _sys
+
+import codin.agent.types as _agent_types
+
 from .config import get_api_key, get_config, load_config
+
 
 def extract_text_from_message(*args, **kwargs):
     from .utils.message import extract_text_from_message as _f
@@ -36,6 +41,7 @@ __all__: list[str] = [
 version: str = '0.1.0'
 
 # Provide backward-compatible imports for `src.codin` paths used in tests
-import sys as _sys
+
+_sys.modules.setdefault('src', _sys.modules[__name__])
 _sys.modules.setdefault('src.codin', _sys.modules[__name__])
-_sys.modules.setdefault('src.codin.agent.types', _sys.modules.get('codin.agent.types'))
+_sys.modules.setdefault('src.codin.agent.types', _agent_types)

--- a/src/codin/actor/ray_scheduler.py
+++ b/src/codin/actor/ray_scheduler.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import typing as _t
 import asyncio
+import typing as _t
 from datetime import datetime
 
 from .supervisor import ActorInfo, ActorSupervisor
@@ -39,9 +39,10 @@ class _RayAgentWrapper:
 
     def run(self, input_data: dict) -> list[dict]:  # pragma: no cover - executed on ray worker
         import asyncio
-        from ..agent.types import AgentRunInput, State, Message
-        from ..tool.base import Tool
+
+        from ..agent.types import AgentRunInput, Message, State
         from ..artifact.base import ArtifactService
+        from ..tool.base import Tool
 
         # Ensure Pydantic models are fully defined on the worker
         State.model_rebuild(

--- a/src/codin/agent/__init__.py
+++ b/src/codin/agent/__init__.py
@@ -9,35 +9,6 @@ in the codin framework.
 from ..memory.base import MemMemoryService, Memory
 from ..model.base import BaseLLM
 from ..tool.base import Tool
-from .base import Agent, Planner
-from .concurrent_runner import ConcurrentRunner
-from .runner import AgentRunner
-from .plan_execute_agent import PlanExecuteAgent
-from .plan_execute_planner import PlanExecutePlanner
-
-# Import new architecture types
-from .types import (
-    AgentRunInput,
-    AgentRunOutput,
-    Event,
-    EventStep,
-    EventType,
-    FinishStep,
-    # A2A Compatible types
-    Message,
-    MessageStep,
-    # Configuration and metrics
-    Metrics,
-    RunConfig,
-    RunEvent,
-    # State and Steps
-    State,
-    Step,
-    StepType,
-    Task,
-    ThinkStep,
-    ToolCallStep,
-)
 
 
 # Lazy imports to avoid circular dependencies
@@ -79,36 +50,11 @@ __all__ = [
     # Base agent interface
     'Agent',
     'Planner',
-    # Input/Output types
-    'AgentRunInput',
-    'AgentRunOutput',
-    # Core architecture types
-    'State',
-    'Step',
-    'StepType',
-    'MessageStep',
-    'EventStep',
-    'ToolCallStep',
-    'ThinkStep',
-    'FinishStep',
-    'EventType',
-    # A2A Compatible types
-    'Message',
-    'Task',
-    'Event',
-    'RunEvent',
-    # Configuration and metrics
-    'Metrics',
-    'RunConfig',
     # Codin architecture components
     'Memory',
     'MemMemoryService',
     'BaseLLM',
     'Tool',
-    'AgentRunner',
-    'ConcurrentRunner',
-    'PlanExecuteAgent',
-    'PlanExecutePlanner',
     # Lazy access functions
     'get_base_agent',
     'get_base_planner',

--- a/src/codin/agent/base_agent.py
+++ b/src/codin/agent/base_agent.py
@@ -13,14 +13,13 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-# Import protocol types that we need
-from .types import Role, TextPart, TaskState, TaskStatus
-
 from ..actor.mailbox import LocalMailbox, Mailbox
 from ..memory.base import MemMemoryService, Memory
 from ..model.base import BaseLLM
 from ..tool.base import Tool, ToolContext
 from .base import Agent, Planner
+
+# Import protocol types that we need
 from .types import (
     AgentRunInput,
     AgentRunOutput,
@@ -30,12 +29,16 @@ from .types import (
     Message,  # Use Message from codin.agent.types
     MessageStep,
     Metrics,
+    Role,
     RunConfig,
     RunnerControl,
     State,
     Step,
     StepType,
     Task,
+    TaskState,
+    TaskStatus,
+    TextPart,
     ThinkStep,
     ToolCallStep,
     ToolUsePart,

--- a/src/codin/agent/base_planner.py
+++ b/src/codin/agent/base_planner.py
@@ -15,12 +15,12 @@ from ..utils.message import (
     format_history_for_prompt,
     format_tool_results_for_conversation,
 )
+from .base import Planner
 from .types import (
     ErrorStep,
     FinishStep,
     Message,
     MessageStep,
-    Planner,
     Role,
     State,
     Step,

--- a/src/codin/agent/code_agent.py
+++ b/src/codin/agent/code_agent.py
@@ -27,8 +27,6 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-# Use protocol types directly
-from .types import Role
 from pydantic import BaseModel
 
 from ..agent.base import Agent, AgentRunInput, AgentRunOutput
@@ -47,7 +45,9 @@ from ..utils.message import (
     format_history_for_prompt,
     format_tool_results_for_conversation,
 )
-from .types import Message, TextPart
+
+# Use protocol types directly
+from .types import Message, Role, TextPart
 
 __all__: list[str] = [
     "AgentEvent",

--- a/src/codin/agent/codeact_planner.py
+++ b/src/codin/agent/codeact_planner.py
@@ -7,14 +7,13 @@ import re
 import typing as _t
 import uuid
 
-# Avoid external dependency on `a2a` by reusing our internal Role enum
-from .types import Role
-
 from ..id import new_id
 from ..sandbox.local import LocalSandbox
 from ..utils.message import extract_text_from_message
 from .base import Planner
-from .types import FinishStep, Message, MessageStep, State, Step, TextPart
+
+# Avoid external dependency on `a2a` by reusing our internal Role enum
+from .types import FinishStep, Message, MessageStep, Role, State, Step, TextPart
 
 
 class CodeActPlanner(Planner):

--- a/src/codin/agent/dag_planner.py
+++ b/src/codin/agent/dag_planner.py
@@ -13,22 +13,21 @@ import logging
 import time
 from datetime import datetime
 
-from .types import (
-    Artifact,
-    DataPart,
-    Message,
-    TaskState,
-    TextPart,
-    Task,
-    TaskStatus,
-)
-
 from ..id import new_id
 from ..model.base import BaseLLM
 from ..prompt import prompt_run
 from ..tool.base import Tool
 from .base import Agent, AgentRunInput, AgentRunOutput
-from .dag_types import Plan, PlanResult, Task, TaskStatus
+from .dag_types import Plan, PlanResult
+from .types import (
+    Artifact,
+    DataPart,
+    Message,
+    Task,
+    TaskState,
+    TaskStatus,
+    TextPart,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/codin/agent/plan_execute_agent.py
+++ b/src/codin/agent/plan_execute_agent.py
@@ -1,9 +1,9 @@
 """Agent that uses :class:`PlanExecutePlanner` for plan-and-execute control."""
 from __future__ import annotations
 
+from .base import Planner
 from .base_agent import BaseAgent
 from .plan_execute_planner import PlanExecutePlanner
-from .types import Planner
 
 
 class PlanExecuteAgent(BaseAgent):

--- a/src/codin/agent/plan_execute_planner.py
+++ b/src/codin/agent/plan_execute_planner.py
@@ -16,17 +16,8 @@ import uuid
 from datetime import datetime
 
 from ..prompt.run import prompt_run
-from .types import (
-    FinishStep,
-    Message,
-    MessageStep,
-    Planner,
-    Role,
-    State,
-    Step,
-    TextPart,
-    ThinkStep,
-)
+from .base import Planner
+from .types import FinishStep, Message, MessageStep, Role, State, Step, TextPart, ThinkStep
 
 logger = logging.getLogger(__name__)
 

--- a/src/codin/agent/search_agent.py
+++ b/src/codin/agent/search_agent.py
@@ -8,9 +8,8 @@ functionality from :class:`BaseAgent` and only overrides the planning loop.
 from __future__ import annotations
 
 import time
-import uuid
 import typing as _t
-
+import uuid
 
 from .base_agent import BaseAgent
 from .types import (
@@ -116,8 +115,16 @@ class SearchAgent(BaseAgent):
                         break
 
                 steps_executed += 1
-                if step.step_type == StepType.MESSAGE and isinstance(step, MessageStep) and step.message:
-                    if not any(h.messageId == step.message.messageId for h in state.history if h.messageId and step.message.messageId):
+                if (
+                    step.step_type == StepType.MESSAGE
+                    and isinstance(step, MessageStep)
+                    and step.message
+                ):
+                    if not any(
+                        h.messageId == step.message.messageId
+                        for h in state.history
+                        if h.messageId and step.message.messageId
+                    ):
                         await self.memory.add_message(step.message)
                         state.history.append(step.message)
 

--- a/src/codin/agent/types.py
+++ b/src/codin/agent/types.py
@@ -1,5 +1,7 @@
 """Type definitions for agent system."""
 
+from __future__ import annotations
+
 import typing as _t
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -52,7 +54,6 @@ __all__ = [
     "FinishStep",
     "ErrorStep",
     # Base interfaces
-    "Planner",
     "EventType",
 ]
 
@@ -129,78 +130,6 @@ class Message:
         )
 
 
-class TaskState(str, Enum):
-    QUEUED = "queued"
-    SUBMITTED = "submitted"
-    WORKING = "working"
-    COMPLETED = "completed"
-    FAILED = "failed"
-
-    queued = QUEUED
-    submitted = SUBMITTED
-    working = WORKING
-    completed = COMPLETED
-    failed = FAILED
-
-
-@dataclass
-class TaskStatus:
-    state: TaskState
-    message: Message | None = None
-    timestamp: str | None = None
-
-
-@dataclass
-class TaskStatusUpdateEvent:
-    contextId: str
-    taskId: str
-    status: TaskStatus
-    final: bool = False
-    metadata: dict[str, _t.Any] = field(default_factory=dict)
-
-
-@dataclass
-class TaskArtifactUpdateEvent:
-    """Event representing artifact updates for a task."""
-
-    contextId: str
-    taskId: str
-    artifact: _t.Any
-    append: bool = False
-    lastChunk: bool = False
-    metadata: dict[str, _t.Any] = field(default_factory=dict)
-
-
-@dataclass
-class Task:
-    id: str
-    contextId: str
-    status: TaskStatus
-    query: str | None = None
-    parts: list[_t.Any] = field(default_factory=list)
-    message: Message | None = None
-    metadata: dict[str, _t.Any] = field(default_factory=dict)
-
-    def add_text_part(self, text: str, metadata: dict[str, _t.Any] | None = None) -> None:
-        self.parts.append(TextPart(text=text, metadata=metadata))
-
-    def add_data_part(self, data: dict[str, _t.Any], metadata: dict[str, _t.Any] | None = None) -> None:
-        """Convenience helper to append a DataPart."""
-        self.parts.append(DataPart(data=data, metadata=metadata))
-
-    def add_tool_call_part(self, call: ToolCall) -> None:
-        self.parts.append(ToolUsePart(type="call", id=call.call_id, name=call.name, input=call.arguments))
-
-    def add_tool_result_part(self, result: ToolCallResult, name: str) -> None:
-        self.parts.append(
-            ToolUsePart(
-                type="result",
-                id=result.call_id,
-                name=name,
-                output=result.output,
-                metadata={"error": result.error} if result.error else None,
-            )
-        )
 
 
 class TaskState(str, Enum):
@@ -285,6 +214,10 @@ class ToolUsePart(_pyd.BaseModel):
 
     metadata: dict[str, _t.Any] | None = None
     """Additional metadata for this tool use"""
+
+
+# Union type for message parts
+Part = TextPart | DataPart | FilePart | ToolUsePart
 
 
 # =============================================================================

--- a/src/codin/cli/commands.py
+++ b/src/codin/cli/commands.py
@@ -10,8 +10,9 @@ import sys
 from pathlib import Path
 
 import click
-from codin.agent.types import Message, Role, TextPart
 from dotenv import load_dotenv
+
+from codin.agent.types import Message, Role, TextPart
 
 from ..agent.base import AgentRunInput
 from ..agent.code_agent import CodeAgent
@@ -659,7 +660,13 @@ def debug_sandbox_cmd(full_auto: bool, permissions: tuple[str, ...], command: tu
 @cli.command("swe-benchmark")
 @click.option("--dataset", default="SWE-bench/SWE-bench_Lite", help="Dataset name or path")
 @click.option("--split", default="test", help="Dataset split")
-@click.option("--predictions", "predictions_path", required=True, type=click.Path(exists=True), help="Path to predictions file")
+@click.option(
+    "--predictions",
+    "predictions_path",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to predictions file",
+)
 @click.option("--instance-id", "instance_ids", multiple=True, help="Instance IDs to run")
 @click.option("--run-id", default=None, help="Run identifier")
 @click.option("--report-dir", default=".", type=click.Path(), help="Directory for reports")

--- a/src/codin/evaluate/swe.py
+++ b/src/codin/evaluate/swe.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Iterable
 
 from swebench.harness.run_evaluation import main as swe_run_main
 

--- a/src/codin/memory/base.py
+++ b/src/codin/memory/base.py
@@ -7,8 +7,9 @@ import typing as _t
 from datetime import datetime
 from enum import Enum
 
-from codin.agent.types import Message, Role, TextPart
 from pydantic import BaseModel, Field
+
+from codin.agent.types import Message, Role, TextPart
 
 __all__ = [
     "ChunkType",

--- a/src/codin/prompt/base.py
+++ b/src/codin/prompt/base.py
@@ -18,14 +18,23 @@ import hashlib
 import typing as _t
 from datetime import datetime
 
+from pydantic import BaseModel, ConfigDict
+
 from codin.agent.types import (
     DataPart as A2ADataPart,
+)
+from codin.agent.types import (
     FilePart as A2AFilePart,
+)
+from codin.agent.types import (
     Message as A2AMessage,
+)
+from codin.agent.types import (
     Role as A2ARole,
+)
+from codin.agent.types import (
     TextPart as A2ATextPart,
 )
-from pydantic import BaseModel, ConfigDict
 
 try:
     from jinja2 import Template as _JinjaTemplate

--- a/src/codin/tool/executor.py
+++ b/src/codin/tool/executor.py
@@ -16,11 +16,12 @@ from contextlib import asynccontextmanager
 
 # Prometheus imports
 import prometheus_client as prom
-from codin.agent.types import Message, TextPart
 
 # OpenTelemetry imports
 from opentelemetry import metrics, trace
 from opentelemetry.trace import Status, StatusCode
+
+from codin.agent.types import Message, TextPart
 
 from ..config import ApprovalMode
 from .base import Tool, ToolContext


### PR DESCRIPTION
## Summary
- ensure `src.codin.agent.types` alias is created after importing types
- point `base_planner` to `Planner` from `base`
- apply Ruff formatting fixes across the codebase

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68452b1c29cc83209d6bc4873e6c5090