### PR TITLE
Refactor agent types to pydantic models

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ The framework follows a modular architecture:
 1. Fork the repository
 2. Create a feature branch
 3. Make your changes
-4. Add tests for new functionality
-5. Run the test suite: `pytest`
-6. Submit a pull request
+4. Install dependencies with `pip install -e .` (or `uv sync`)
+5. Add tests for new functionality
+6. Run the test suite: `pytest`
+7. Submit a pull request
 
 ## License
 

--- a/src/codin/agent/types.py
+++ b/src/codin/agent/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import typing as _t
-from dataclasses import dataclass, field
+from uuid import uuid4
 from datetime import datetime
 from enum import Enum
 
@@ -67,36 +67,32 @@ class Role(str, Enum):
     assistant = "assistant"
 
 
-@dataclass
-class TextPart:
+class TextPart(BaseModel):
     text: str
     kind: str = "text"
     metadata: dict[str, _t.Any] | None = None
 
 
-@dataclass
-class DataPart:
+class DataPart(BaseModel):
     data: dict[str, _t.Any]
     kind: str = "data"
     metadata: dict[str, _t.Any] | None = None
 
 
-@dataclass
-class FilePart:
+class FilePart(BaseModel):
     uri: str | None = None
     path: str | None = None
     kind: str = "file"
     metadata: dict[str, _t.Any] | None = None
 
 
-@dataclass
-class Message:
-    messageId: str
+class Message(BaseModel):
+    messageId: str = Field(default_factory=lambda: str(uuid4()))
     role: Role
     parts: list[_t.Any]
     contextId: str | None = None
     kind: str = "message"
-    metadata: dict[str, _t.Any] = field(default_factory=dict)
+    metadata: dict[str, _t.Any] = Field(default_factory=dict)
     taskId: str | None = None
     referenceTaskIds: list[str] | None = None
 


### PR DESCRIPTION
## Summary
- remove dataclass usage in `agent.types`
- implement `TextPart`, `DataPart`, `FilePart`, and `Message` as pydantic models
- auto-generate `Message.messageId`
- clarify README instructions for setting up tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684550f2b2d483208cb20845f34aa256