### PR TITLE
Add RAP Trinity agent components

### DIFF
--- a/src/codin/agent/__init__.py
+++ b/src/codin/agent/__init__.py
@@ -10,6 +10,30 @@ from ..memory.base import MemMemoryService, Memory
 from ..model.base import BaseLLM
 from ..tool.base import Tool
 
+# Core interfaces and implementations
+from .base import Agent, Planner, TaskExecutor, StepExecutor
+from .types import (
+    TaskControl,
+    AgentRunInput,
+    AgentRunOutput,
+    StepType,
+    Step,
+    MessageStep,
+    ToolCallStep,
+    PlanStep,
+    FinishStep,
+    Plan,
+    State,
+    Message,
+    Role,
+)
+from .session import Session
+from .runner import AgentRunner as Runner
+from .agent import BasicAgent
+from .planners import BasicPlanner, ReactivePlanner, CodingAssistantPlanner
+from .discovery import AgentRegistry
+from .distributed import RayAgent, AgentFactory
+
 
 # Lazy imports to avoid circular dependencies
 def get_base_agent():
@@ -47,20 +71,47 @@ def get_search_agent():
 
 
 __all__ = [
-    # Base agent interface
-    'Agent',
-    'Planner',
-    # Codin architecture components
-    'Memory',
-    'MemMemoryService',
-    'BaseLLM',
-    'Tool',
-    # Lazy access functions
-    'get_base_agent',
-    'get_base_planner',
-    'get_code_agent',
-    'get_codeact_planner',
-    'get_search_agent',
+    # Core interfaces
+    "Agent",
+    "Planner",
+    "TaskExecutor",
+    "StepExecutor",
+    # Core types
+    "TaskControl",
+    "AgentRunInput",
+    "AgentRunOutput",
+    "StepType",
+    "Step",
+    "MessageStep",
+    "ToolCallStep",
+    "PlanStep",
+    "FinishStep",
+    "Plan",
+    "State",
+    "Message",
+    "Role",
+    # Core implementations
+    "Session",
+    "Runner",
+    "BasicAgent",
+    # Planners
+    "BasicPlanner",
+    "ReactivePlanner",
+    "CodingAssistantPlanner",
+    # Services
+    "AgentRegistry",
+    "RayAgent",
+    "AgentFactory",
+    # Legacy exports
+    "Memory",
+    "MemMemoryService",
+    "BaseLLM",
+    "Tool",
+    "get_base_agent",
+    "get_base_planner",
+    "get_code_agent",
+    "get_codeact_planner",
+    "get_search_agent",
 ]
 
 

--- a/src/codin/agent/agent.py
+++ b/src/codin/agent/agent.py
@@ -1,0 +1,41 @@
+import time
+import uuid
+from typing import AsyncIterator, List
+
+from .base import Agent, Planner
+from .types import (
+    AgentRunInput,
+    AgentRunOutput,
+    State,
+    MessageStep,
+    FinishStep,
+    Message,
+    Role,
+    TextPart,
+    RunConfig,
+)
+from .session import Session
+
+
+class BasicAgent(Agent):
+    """Stateful agent execution loop controller."""
+
+    def __init__(self, planner: Planner, *, tools: List = None, memory=None) -> None:
+        super().__init__(name="BasicAgent", description="Simple agent", tools=tools)
+        self.planner = planner
+        self.memory = memory
+
+    async def run(self, input: AgentRunInput) -> AsyncIterator[AgentRunOutput]:
+        session = Session(memory=self.memory, tools=self.tools, config=input.metadata.get("config", {}) if input.metadata else RunConfig())
+        state = State(session_id=input.session_id or uuid.uuid4().hex, agent_id=self.id, history=await session.get_history(), pending=[input.message], tools=self.tools)
+        steps = await self.planner.plan(state)
+        for step in steps:
+            if isinstance(step, MessageStep) and step.message:
+                await session.add_message(step.message)
+                yield step.message
+            if isinstance(step, FinishStep):
+                break
+        return
+
+    async def cleanup(self) -> None:
+        pass

--- a/src/codin/agent/base.py
+++ b/src/codin/agent/base.py
@@ -16,6 +16,7 @@ from ..actor.types import ActorRunInput, ActorRunOutput
 from .types import (
     State,
     Step,
+    Plan,
 )
 from ..tool.base import Tool # Tools are generic
 from ..id import new_id # For generating default IDs
@@ -24,6 +25,8 @@ from ..id import new_id # For generating default IDs
 __all__ = [
     'Agent',
     'Planner',
+    'TaskExecutor',
+    'StepExecutor',
 ]
 
 
@@ -137,3 +140,15 @@ class Planner(abc.ABC):
                    the planner.
         """
         ... # Ellipsis for abstract method
+
+
+class TaskExecutor(_t.Protocol):
+    """Protocol for executing high-level plans."""
+
+    async def execute_dag_plan(self, plan: "Plan") -> _t.Any: ...
+
+
+class StepExecutor(_t.Protocol):
+    """Protocol for executing individual steps."""
+
+    async def execute_step(self, step: Step, state: State) -> _t.Any: ...

--- a/src/codin/agent/discovery.py
+++ b/src/codin/agent/discovery.py
@@ -1,0 +1,25 @@
+from typing import Dict, List
+
+from .base import Agent
+from .types import Message
+
+
+class AgentRegistry:
+    """Service for agent discovery and routing."""
+
+    def __init__(self) -> None:
+        self._agents: Dict[str, Agent] = {}
+        self._capabilities: Dict[str, List[str]] = {}
+
+    def register_agent(self, agent_id: str, agent: Agent, capabilities: List[str]) -> None:
+        self._agents[agent_id] = agent
+        self._capabilities[agent_id] = capabilities
+
+    def _extract_content(self, message: Message) -> str:
+        return " ".join(getattr(p, "text", "") for p in message.parts)
+
+    def find_agent(self, message: Message, context: dict) -> Agent | None:
+        for agent_id, caps in self._capabilities.items():
+            if any(keyword in self._extract_content(message).lower() for keyword in caps):
+                return self._agents[agent_id]
+        return next(iter(self._agents.values()), None)

--- a/src/codin/agent/distributed.py
+++ b/src/codin/agent/distributed.py
@@ -1,0 +1,36 @@
+import ray
+
+from .agent import BasicAgent
+from .base import Agent, Planner
+from .types import AgentRunInput
+
+
+@ray.remote
+class RayAgent:
+    """Agent running as Ray actor on remote compute node."""
+
+    def __init__(self, planner: Planner):
+        self.planner = planner
+
+    async def run(self, input_dict: dict) -> list[dict]:
+        input_data = AgentRunInput.model_validate(input_dict)
+        agent = BasicAgent(self.planner)
+        results = []
+        async for output in agent.run(input_data):
+            if hasattr(output, "model_dump"):
+                results.append(output.model_dump())
+            else:
+                results.append(output)
+        return results
+
+
+class AgentFactory:
+    """Factory for creating different agent implementations."""
+
+    @staticmethod
+    def create_agent(deployment_type: str, planner: Planner) -> Agent:
+        if deployment_type == "local":
+            return BasicAgent(planner)
+        if deployment_type == "ray":
+            return RayAgent.remote(planner)
+        raise ValueError(f"Unknown deployment: {deployment_type}")

--- a/src/codin/agent/executors/__init__.py
+++ b/src/codin/agent/executors/__init__.py
@@ -1,0 +1,5 @@
+"""Execution helpers for agent plans."""
+
+from .task_executor import TaskExecutor
+
+__all__ = ["TaskExecutor"]

--- a/src/codin/agent/executors/task_executor.py
+++ b/src/codin/agent/executors/task_executor.py
@@ -1,0 +1,17 @@
+from ..tool.base import Toolset
+
+
+class TaskExecutor:
+    """Unified executor for different plan types."""
+
+    def __init__(self, tools: Toolset):
+        self.tools = tools
+
+    async def execute_dag_plan(self, plan: 'dag_types.Plan') -> 'PlanResult':
+        from ..dag_planner import DAGExecutor
+        dag_executor = DAGExecutor(tools=self.tools)
+        return await dag_executor.execute_plan(plan)
+
+    async def execute_workflow_plan(self, plan: 'WorkflowPlan') -> 'PlanResult':
+        """Execute workflow-based plan (placeholder)."""
+        return None

--- a/src/codin/agent/planner.py
+++ b/src/codin/agent/planner.py
@@ -1,0 +1,91 @@
+import json
+import uuid
+from typing import Any, Dict, List
+
+from .base import Planner
+from .types import (
+    State,
+    Step,
+    StepType,
+    MessageStep,
+    ToolCallStep,
+    FinishStep,
+    Message,
+    Role,
+    TextPart,
+    ToolUsePart,
+)
+from ..model.base import BaseLLM
+
+
+class BasicPlanner(Planner):
+    """JSON action-based LLM planner generating structured responses."""
+
+    def __init__(self, llm: BaseLLM, system_prompt: str | None = None):
+        self.llm = llm
+        self.system_prompt = system_prompt or self._default_system_prompt()
+
+    async def plan(self, state: State) -> List[Step]:
+        """Generate next steps using LLM with JSON action output."""
+        context = await self._build_context(state)
+        messages = await self._build_llm_messages(context, state)
+        response = await self.llm.generate(messages=messages, temperature=0.3)
+        return await self._parse_json_response_to_steps(response, state)
+
+    async def _build_context(self, state: State) -> Dict[str, Any]:
+        return {
+            "available_tools": [t.name for t in state.tools],
+            "recent_history": [self._extract_content(m) for m in state.history[-5:]],
+            "constraints": "",
+        }
+
+    async def _build_llm_messages(self, context: Dict[str, Any], state: State) -> List[Dict[str, str]]:
+        system = self.system_prompt.format(**context)
+        messages = [{"role": "system", "content": system}]
+        if state.pending:
+            user_msg = self._extract_content(state.pending[-1])
+            messages.append({"role": "user", "content": user_msg})
+        return messages
+
+    async def _parse_json_response_to_steps(self, response: str, state: State) -> List[Step]:
+        try:
+            data = json.loads(response)
+        except Exception:
+            msg = Message(role=Role.agent, parts=[TextPart(text=response)])
+            return [MessageStep(step_id=str(uuid.uuid4()), message=msg)]
+
+        if isinstance(data, str) and data.strip().lower() == "done":
+            return [FinishStep(step_id=str(uuid.uuid4()), reason="LLM signaled done")]
+
+        steps: List[Step] = []
+        if isinstance(data, list):
+            for item in data:
+                if item.get("type") == "message":
+                    msg = Message(role=Role.agent, parts=[TextPart(text=item.get("content", ""))])
+                    steps.append(MessageStep(step_id=str(uuid.uuid4()), message=msg))
+                elif item.get("type") == "tool_call":
+                    call = ToolUsePart(
+                        kind="tool-use",
+                        type="call",
+                        id=str(uuid.uuid4()),
+                        name=item.get("tool", ""),
+                        input=item.get("parameters", {}),
+                    )
+                    steps.append(ToolCallStep(step_id=str(uuid.uuid4()), tool_call=call))
+        return steps
+
+    def _extract_content(self, message: Message) -> str:
+        texts = [getattr(p, "text", "") for p in message.parts]
+        return "\n".join(texts)
+
+    def _default_system_prompt(self) -> str:
+        return (
+            "You are a helpful AI assistant. Respond with either \"done\" or JSON actions.\n\n"
+            "CONTEXT:\n"
+            "Available Tools: {available_tools}\n"
+            "Recent History: {recent_history}\n"
+            "Constraints: {constraints}\n\n"
+            "RESPONSE FORMAT:\n"
+            "1. \"done\" - if task is complete\n"
+            "2. JSON list: [{\"type\": \"message\", \"content\": \"text\"}, {\"type\": \"tool_call\", \"tool\": \"name\", \"parameters\": {...}}]"
+        )

--- a/src/codin/agent/planners/__init__.py
+++ b/src/codin/agent/planners/__init__.py
@@ -1,0 +1,5 @@
+from .basic import BasicPlanner
+from .reactive import ReactivePlanner
+from .coding import CodingAssistantPlanner
+
+__all__ = ["BasicPlanner", "ReactivePlanner", "CodingAssistantPlanner"]

--- a/src/codin/agent/planners/basic.py
+++ b/src/codin/agent/planners/basic.py
@@ -1,0 +1,3 @@
+from ..planner import BasicPlanner
+
+__all__ = ["BasicPlanner"]

--- a/src/codin/agent/planners/coding.py
+++ b/src/codin/agent/planners/coding.py
@@ -1,0 +1,17 @@
+from ..planner import BasicPlanner
+
+
+class CodingAssistantPlanner(BasicPlanner):
+    """Specialized planner for coding tasks."""
+
+    def _default_system_prompt(self) -> str:
+        return (
+            "You are an expert coding assistant. Respond with JSON actions for programming tasks.\n\n"
+            "CODING WORKFLOW:\n"
+            "1. Read relevant files using tools\n"
+            "2. Analyze code structure\n"
+            "3. Make necessary changes\n"
+            "4. Run tests to verify\n\n"
+            "TOOLS: {available_tools}\n"
+            "HISTORY: {recent_history}\n"
+        )

--- a/src/codin/agent/planners/reactive.py
+++ b/src/codin/agent/planners/reactive.py
@@ -1,0 +1,18 @@
+from ..base import Planner
+from ..types import State, Step, MessageStep, FinishStep, Message, Role, TextPart
+
+
+class ReactivePlanner(Planner):
+    """Simple reactive planner for immediate responses."""
+
+    async def plan(self, state: State) -> list[Step]:
+        if not state.pending:
+            return [FinishStep(step_id="finish", reason="No pending messages")]
+
+        latest = state.pending[-1]
+        response_text = f"I received: {self._extract_content(latest)}"
+        msg = Message(role=Role.agent, parts=[TextPart(text=response_text)])
+        return [MessageStep(step_id="reply", message=msg, is_streaming=True)]
+
+    def _extract_content(self, message: Message) -> str:
+        return " ".join(getattr(p, "text", "") for p in message.parts)

--- a/src/codin/agent/session.py
+++ b/src/codin/agent/session.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List
+
+from ..memory.base import Memory
+from ..tool.base import Tool
+from .types import RunConfig
+
+
+@dataclass
+class Session:
+    """Execution context with tools, memory and config."""
+
+    memory: Memory
+    tools: List[Tool] = field(default_factory=list)
+    config: RunConfig = field(default_factory=RunConfig)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    async def add_message(self, message: "Message") -> None:
+        await self.memory.add_message(message)
+
+    async def get_history(self, limit: int = 50) -> List["Message"]:
+        return await self.memory.get_history(limit=limit)


### PR DESCRIPTION
## Summary
- implement `BasicPlanner` and new planner package
- add discovery, distributed, and executor modules
- expand agent types with plan capabilities
- implement `BasicAgent` and session container
- update exports for new RAP components

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_684c0a4bb9108320a06e005b4f882486