### PR TITLE
Partial test prep

### DIFF
--- a/src/codin/prompt
+++ b/src/codin/prompt
@@ -1,1 +1,0 @@
-/home/jucheng/gh/my/prompti/src/prompti

--- a/src/codin/prompt/__init__.py
+++ b/src/codin/prompt/__init__.py
@@ -1,0 +1,37 @@
+"""Wrapper module exposing the :mod:`prompti` package under ``codin.prompt``.
+
+This repository's original sources expected the ``codin.prompt`` package to be
+provided via a local checkout of the `prompti` project. In this trimmed
+repository we simply re-export the installed :mod:`prompti` package so that the
+rest of the code and tests can import ``codin.prompt`` transparently.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import prompti as _prompti
+
+# Re-export commonly used submodules so imports like
+# ``from codin.prompt.engine import PromptEngine`` continue to work.
+for _name in (
+    "base",
+    "engine",
+    "registry",
+    "run",
+    "loader",
+    "message",
+    "model_client",
+    "experiment",
+):
+    try:
+        _mod = importlib.import_module(f"prompti.{_name}")
+        sys.modules[f"{__name__}.{_name}"] = _mod
+    except Exception:  # pragma: no cover - optional extras
+        pass
+
+# Re-export everything defined by prompti at the package level
+from prompti import *  # type: ignore F401,F403
+
+__all__ = getattr(_prompti, "__all__", [])

--- a/src/codin/tool/base.py
+++ b/src/codin/tool/base.py
@@ -10,7 +10,7 @@ from enum import Enum
 import pydantic as _pyd
 from pydantic import BaseModel, ConfigDict
 
-from ..lifecycle import LifecycleMixin
+from ..lifecycle import LifecycleMixin, LifecycleState
 
 __all__ = [
     'Tool',
@@ -19,6 +19,9 @@ __all__ = [
     'ToolDefinition',
     'ToolSpec',
     'ToolMetadata',
+    'LifecycleState',
+    'to_tool_definition',
+    'to_tool_definitions',
 ]
 
 
@@ -252,3 +255,18 @@ def to_definitions(tools: list[Tool | ToolDefinition] | None) -> list[ToolDefini
     if not tools:
         return []
     return [to_definition(tool) for tool in tools]
+
+
+# ---------------------------------------------------------------------------
+# Compatibility helpers
+# ---------------------------------------------------------------------------
+
+def to_tool_definition(tool: Tool | ToolDefinition) -> ToolDefinition:
+    """Alias for :func:`to_definition` for backwards compatibility."""
+    return to_definition(tool)
+
+
+def to_tool_definitions(tools: list[Tool | ToolDefinition] | None) -> list[ToolDefinition]:
+    """Alias for :func:`to_definitions` for backwards compatibility."""
+    return to_definitions(tools)
+

--- a/src/codin/utils/message.py
+++ b/src/codin/utils/message.py
@@ -3,9 +3,44 @@
 from __future__ import annotations
 
 __all__ = [
+    "extract_text_from_message",
     "format_history_for_prompt",
     "format_tool_results_for_conversation",
 ]
+
+
+def extract_text_from_message(message: object) -> str:
+    """Extract plain text content from a message object."""
+    if message is None:
+        return ""
+
+    if isinstance(message, str):
+        return message
+
+    # Support simple dict representations used in tests
+    if isinstance(message, dict):
+        if "content" in message:
+            return message["content"]
+        if "parts" in message:
+            return "\n".join(p.get("text", "") for p in message["parts"])
+
+    # Pydantic Message models have ``parts`` with TextPart objects
+    parts = getattr(message, "parts", None)
+    if parts:
+        texts = []
+        for part in parts:
+            text = getattr(part, "text", None)
+            if text:
+                texts.append(text)
+        if texts:
+            return "\n".join(texts)
+
+    # Fallback to ``content`` attribute
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return content
+
+    return ""
 
 
 def format_history_for_prompt(history_messages: list[dict]) -> str:


### PR DESCRIPTION
## Summary
- stub out `codin.prompt` package
- expose lifecycle helpers in tool base
- add message extraction helper

## Testing
- `pytest tests/utils/test_message_utils.py::test_extract_text_from_message`


------
https://chatgpt.com/codex/tasks/task_e_6860889cc12c8320b6fd47ced1ca0333